### PR TITLE
Default to kaspr v0.6.7

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.6.1",
+            version="0.6.7",
+            image="kasprio/kaspr:0.6.7-alpha",
+            supported=True,
+            default=True,
+        ),            
+        KasprVersion(
             operator_version="0.6.0",
             version="0.6.0",
             image="kasprio/kaspr:0.6.6-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),        
         KasprVersion(
             operator_version="0.5.28",


### PR DESCRIPTION
This pull request updates the Kaspr versioning to support a new operator and application version, and ensures that the latest version is now set as the default. The main changes are:

Versioning updates:

* Added a new `KasprVersion` entry for operator version `0.6.1`, mapping it to application version `0.6.7` and image `kasprio/kaspr:0.6.7-alpha`, and set it as the new default version.
* Updated the previous default (`operator_version="0.6.0"`) to no longer be the default.

Package version bump:

* Bumped the package version in `kaspr/__init__.py` from `0.6.0` to `0.6.1`.