### PR TITLE
Update version to 0.6.2 and schema base class

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
-            operator_version="0.6.1",
+            operator_version="0.6.2",
             version="0.6.7",
             image="kasprio/kaspr:0.6.7-alpha",
             supported=True,
             default=True,
+        ),          
+        KasprVersion(
+            operator_version="0.6.1",
+            version="0.6.7",
+            image="kasprio/kaspr:0.6.7-alpha",
+            supported=True,
+            default=False,
         ),            
         KasprVersion(
             operator_version="0.6.0",

--- a/kaspr/types/schemas/kasprwebview_spec.py
+++ b/kaspr/types/schemas/kasprwebview_spec.py
@@ -55,7 +55,7 @@ class KasprWebViewProcessorOperationSchema(BaseSchema):
         return camel_to_snake(data)
 
 
-class KasprWebViewProcessorInitSchema(BaseSchema):
+class KasprWebViewProcessorInitSchema(CodeSpecSchema):
     __model__ = KasprWebViewProcessorsInit
 
 


### PR DESCRIPTION
* Fix: change KasprWebViewProcessorInitSchema to inherit from CodeSpecSchema instead of BaseSchema
* Bump package version to 0.6.2.