### PR TITLE
Update version to 0.6.4 and adjust version resources

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.6.3"
+__version__ = "0.6.4"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.6.3",
+            version="0.6.8",
+            image="kasprio/kaspr:0.6.8-alpha",
+            supported=True,
+            default=True,
+        ),          
+        KasprVersion(
             operator_version="0.6.2",
             version="0.6.7",
             image="kasprio/kaspr:0.6.7-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.6.1",


### PR DESCRIPTION
* Bump kaspr package version to 0.6.4.
* Add operator version 0.6.3 as the new default in KasprVersionResources