### PR TITLE
Support for KasprApp status

### DIFF
--- a/crds/kasprapp.crd.yaml
+++ b/crds/kasprapp.crd.yaml
@@ -959,3 +959,48 @@ spec:
             status:
               type: object
               x-kubernetes-preserve-unknown-fields: true
+              properties:
+                observedGeneration:
+                  type: integer
+                  format: int64
+                kasprVersion:
+                  type: string
+                conditions:
+                  type: array
+                  x-kubernetes-list-type: map
+                  x-kubernetes-list-map-keys:
+                    - type
+                  items:
+                    type: object
+                    required:
+                      - type
+                      - status
+                      - reason
+                      - lastTransitionTime
+                      - observedGeneration
+                    properties:
+                      type:
+                        type: string
+                        minLength: 1
+                      status:
+                        type: string
+                        enum: ["True","False","Unknown"]
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      lastTransitionTime:
+                        type: string
+                        format: date-time
+                      observedGeneration:
+                        type: integer
+                        format: int64   
+      subresources:
+        status: {}      
+      additionalPrinterColumns:
+      - name: Ready
+        jsonPath: .status.conditions[?(@.type=="Ready")].status
+        type: string
+      - name: Kaspr
+        jsonPath: .status.kasprVersion
+        type: string

--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.6.5"
+__version__ = "0.7.0"

--- a/kaspr/resources/base.py
+++ b/kaspr/resources/base.py
@@ -259,7 +259,12 @@ class BaseResource:
         namespace: str,
         delete_options: V1DeleteOptions,
     ):
-        apps_v1_api.delete_namespaced_stateful_set(name, namespace, body=delete_options)
+        try:
+            apps_v1_api.delete_namespaced_stateful_set(name, namespace, body=delete_options)
+        except ApiException as ex:
+            if ex.status == 404:
+                return
+            raise
 
     def fetch_secret(
         self, core_v1_api: CoreV1Api, name: str, namespace: str

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.7.0",
+            version="0.6.10",
+            image="kasprio/kaspr:0.6.10-alpha",
+            supported=True,
+            default=True,
+        ),            
+        KasprVersion(
             operator_version="0.6.5",
             version="0.6.9",
             image="kasprio/kaspr:0.6.9-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.6.3",

--- a/kaspr/types/schemas/storage.py
+++ b/kaspr/types/schemas/storage.py
@@ -8,7 +8,7 @@ class KasprAppStorageSchema(BaseSchema):
 
     __model__ = KasprAppStorage
 
-    type = fields.Str(data_key="type", default=None)
+    type = fields.Str(data_key="type", required=True)
     storage_class = fields.Str(data_key="class", required=True)
     size = fields.Str(data_key="size", required=True)
-    delete_claim = fields.Bool(data_key="deleteClaim", default=None)
+    delete_claim = fields.Bool(data_key="deleteClaim", load_default=None)


### PR DESCRIPTION
This pull request introduces several improvements and enhancements to the Kaspr operator and application, focusing on status reporting, API robustness, schema validation, and version management. The main changes include expanding the CRD status schema, improving error handling for resource deletion, updating version mappings, and refining helper utilities.

**CRD and Status Reporting Enhancements:**

- Expanded the `kasprapp.crd.yaml` status schema to include `observedGeneration`, `kasprVersion`, and a structured `conditions` array for better status tracking and observability. Also added printer columns for `Ready` and `Kaspr` version.
- Added a `fetch_app_status` method to `kasprapp.py` to retrieve the application's current Kaspr version and available replicas from its StatefulSet.

**API and Resource Handling Improvements:**

- Improved `delete_stateful_set` in `base.py` to gracefully handle `404 Not Found` errors by catching the exception and returning early, preventing unnecessary failures.

**Version and Schema Management:**

- Updated the Kaspr operator and application version mapping: added support for operator version `0.7.0` (default), and made `0.6.5` non-default. [[1]](diffhunk://#diff-72ae4e4a2b1e86ceb013a042a92b9185c3a7ec98a62833e45a854dfcfc3d30daR25-R37) [[2]](diffhunk://#diff-2fe653280a4f04f8f978c8e4f55b4a2cbb71bace93e5fc4fc848ada99b7ddbd0L17-R17)
- Modified `KasprAppStorageSchema` to require the `type` field and clarified the defaulting behavior for `delete_claim`.

**Helper Utilities:**

- Added a new `now()` function returning ISO-formatted UTC time and updated `utc_now()` to clarify its return type.
- Introduced `upsert_condition` helper for merging condition arrays by type and updating `lastTransitionTime` only when the status changes, supporting improved status management.

**Miscellaneous:**

- Fixed environment variable preparation in `kasprapp.py` to use the correct hash attributes (`webviews_hash` and `tables_hash`).