### PR TITLE
Add HPA support and reconciliation pause for KasprApp

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.7.0"
+__version__ = "0.7.1"

--- a/kaspr/handlers/kasprapp.py
+++ b/kaspr/handlers/kasprapp.py
@@ -798,3 +798,13 @@ async def monitor_related_resources(
 async def periodic_reconciliation(name, **kwargs):
     """Reconcile KasprApp resources."""
     await request_reconciliation(name, **kwargs)
+
+@kopf.on.field(kind=APP_KIND, field='metadata.annotations', annotations={'kaspr.io/pause-reconciliation': kopf.PRESENT})
+async def on_reconciliation_paused(name, diff, spec, namespace, logger: Logger, **kwargs):
+    """Handle reconciliation paused event."""
+    await request_reconciliation(name, **kwargs)
+
+@kopf.on.field(kind=APP_KIND, field='metadata.annotations', annotations={'kaspr.io/pause-reconciliation': kopf.ABSENT})
+async def on_reconciliation_resumed(name, diff, spec, namespace, logger: Logger, **kwargs):
+    """Handle reconciliation resumed event."""
+    await request_reconciliation(name, **kwargs)

--- a/kaspr/types/models/kasprapp_resources.py
+++ b/kaspr/types/models/kasprapp_resources.py
@@ -42,3 +42,7 @@ class KasprAppResources:
     @classmethod
     def stateful_set_name(self, cluster_name: str):
         return self.component_name(cluster_name)
+    
+    @classmethod
+    def hpa_name(self, cluster_name: str):
+        return f"{cluster_name}-app-hpa"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.7.1",
+            version="0.6.11",
+            image="kasprio/kaspr:0.6.11-alpha",
+            supported=True,
+            default=True,
+        ),            
+        KasprVersion(
             operator_version="0.7.0",
             version="0.6.10",
             image="kasprio/kaspr:0.6.10-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),            
         KasprVersion(
             operator_version="0.6.5",


### PR DESCRIPTION
* Introduces Horizontal Pod Autoscaler (HPA) management for KasprApp resources, including creation, patching, and deletion logic.
* Adds support for pausing and resuming reconciliation via annotations, ensuring HPA is deleted when reconciliation is paused or replicas are set to zero.
* Updates resource and version models to support HPA naming and version mapping.
* Bumps version to 0.7.1.