### PR TITLE
Bump version to 0.7.5 and update HPA scaling policies

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.7.4"
+__version__ = "0.7.5"

--- a/kaspr/resources/kasprapp.py
+++ b/kaspr/resources/kasprapp.py
@@ -1161,16 +1161,16 @@ class KasprApp(BaseResource):
                             V2HPAScalingPolicy(
                                 type="Percent",
                                 value=100,
-                                period_seconds=60,
+                                period_seconds=90,
                             ),
                             V2HPAScalingPolicy(
                                 type="Pods",
                                 value=4,
-                                period_seconds=60,
+                                period_seconds=90,
                             ),
                         ],
                         select_policy="Max",
-                        stabilization_window_seconds=0,
+                        stabilization_window_seconds=30,
                     ),
                     scale_down=V2HPAScalingRules(
                         policies=[

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
-            operator_version="0.7.4",
+            operator_version="0.7.5",
             version="0.6.11",
             image="kasprio/kaspr:0.6.11-alpha",
             supported=True,
             default=True,
+        ),          
+        KasprVersion(
+            operator_version="0.7.4",
+            version="0.6.11",
+            image="kasprio/kaspr:0.6.11-alpha",
+            supported=True,
+            default=False,
         ),           
         KasprVersion(
             operator_version="0.7.1",


### PR DESCRIPTION
* Updated 0.7.5.
* Adjusted HPA scaling policy periods and stabilization window in KasprApp.