### PR TITLE
Bump version to 0.7.6 and update scaling policies

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -14,4 +14,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.7.5"
+__version__ = "0.7.6"

--- a/kaspr/resources/kasprapp.py
+++ b/kaspr/resources/kasprapp.py
@@ -1161,16 +1161,16 @@ class KasprApp(BaseResource):
                             V2HPAScalingPolicy(
                                 type="Percent",
                                 value=100,
-                                period_seconds=90,
+                                period_seconds=120,
                             ),
                             V2HPAScalingPolicy(
                                 type="Pods",
                                 value=4,
-                                period_seconds=90,
+                                period_seconds=120,
                             ),
                         ],
                         select_policy="Max",
-                        stabilization_window_seconds=30,
+                        stabilization_window_seconds=0,
                     ),
                     scale_down=V2HPAScalingRules(
                         policies=[

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
-            operator_version="0.7.5",
+            operator_version="0.7.6",
             version="0.6.11",
             image="kasprio/kaspr:0.6.11-alpha",
             supported=True,
             default=True,
+        ),             
+        KasprVersion(
+            operator_version="0.7.5",
+            version="0.6.11",
+            image="kasprio/kaspr:0.6.11-alpha",
+            supported=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.7.4",


### PR DESCRIPTION
* Updated o 0.7.6.
* Adjusted HPA scaling policy periods from 90 to 120 seconds and set stabilization_window_seconds to 0 in kasprapp.py.
* Added a new KasprVersion entry for operator version 0.7.5 with default set to False in version_resources.py.