### PR TITLE
Bump version to 0.7.8 and update version resources

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.7.7"
+__version__ = "0.7.8"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
-            operator_version="0.7.6",
+            operator_version="0.7.8",
             version="0.6.11",
             image="kasprio/kaspr:0.6.11-alpha",
             supported=True,
             default=True,
+        ),           
+        KasprVersion(
+            operator_version="0.7.6",
+            version="0.6.11",
+            image="kasprio/kaspr:0.6.11-alpha",
+            supported=True,
+            default=False,
         ),             
         KasprVersion(
             operator_version="0.7.5",


### PR DESCRIPTION
Updated __version__ to 0.7.8 in kaspr/__init__.py. Modified KasprVersionResources to set 0.7.8 as the default operator version and added a non-default entry for 0.7.6.