### PR TITLE
Update to version 0.7.9 and enhance HPA patching

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.7.8"
+__version__ = "0.7.9"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
-            operator_version="0.7.8",
+            operator_version="0.7.9",
             version="0.6.11",
             image="kasprio/kaspr:0.6.11-alpha",
             supported=True,
             default=True,
+        ),          
+        KasprVersion(
+            operator_version="0.7.8",
+            version="0.6.11",
+            image="kasprio/kaspr:0.6.11-alpha",
+            supported=True,
+            default=False,
         ),           
         KasprVersion(
             operator_version="0.7.6",


### PR DESCRIPTION
Bump the kaspr package version to 0.7.9 and update version resources accordingly. Improve HPA patching logic in KasprApp to handle scaleUp policies' periodSeconds and value fields, ensuring more accurate updates to HPA behavior.