### PR TITLE
Improving the status reporting

### DIFF
--- a/crds/kasprapp.crd.yaml
+++ b/crds/kasprapp.crd.yaml
@@ -1001,6 +1001,9 @@ spec:
       - name: Ready
         jsonPath: .status.conditions[?(@.type=="Ready")].status
         type: string
-      - name: Kaspr
+      - name: Version
         jsonPath: .status.kasprVersion
         type: string
+      - name: Replicas
+        jsonPath: .status.availableReplicas
+        type: integer

--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -27,4 +27,4 @@ __all__ = [
     "kasprtable",
 ]
 
-__version__ = "0.8.0"
+__version__ = "0.8.1"


### PR DESCRIPTION
This pull request focuses on improving the status reporting and scaling behavior of the `KasprApp` resource, as well as making some minor version and documentation updates. The main changes include enhancements to the Custom Resource Definition (CRD) and status handling to better track replica counts, and clarifications in the autoscaling logic.

**Status and CRD improvements:**

* The `KasprApp` CRD (`crds/kasprapp.crd.yaml`) now exposes `Version` (formerly `Kaspr`) and a new `Replicas` field, making it easier to monitor application version and replica count from the CRD status.
* The status update logic in `kaspr/handlers/kasprapp.py` was refactored to consistently use a local `_status` variable, and now tracks both `desiredReplicas` and `availableReplicas` in the status patch. [[1]](diffhunk://#diff-4a7b90b24211e2eea8630e5e39c3a4e07f2e89d302a321f5281d41403e421151R76-R79) [[2]](diffhunk://#diff-4a7b90b24211e2eea8630e5e39c3a4e07f2e89d302a321f5281d41403e421151L89-R99)
* The application status (`fetch_app_status`) now includes both `availableReplicas` and `desiredReplicas`, providing a more complete picture of the app's state.

**Autoscaling and documentation:**

* The autoscaler documentation and implementation were updated: scaling is now described in terms of scaling up to N pods and using memory (1Mi) as the metric, instead of CPU.
* The HPA watch fields logic was updated to correctly construct the `policies` field as a list of objects, improving compatibility and clarity.

**Other:**

* The package version was bumped from `0.8.0` to `0.8.1`.