### PR TITLE
Bump version to 0.16.2 and add 0.8.2 resource

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.16.1"
+__version__ = "0.16.2"

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -24,10 +24,17 @@ class KasprVersionResources:
     _VERSIONS = (
         KasprVersion(
             operator_version="0.16.0",
+            version="0.8.2",
+            image="kasprio/kaspr:0.8.2-alpha",
+            supported=True,
+            default=True,
+        ),        
+        KasprVersion(
+            operator_version="0.16.0",
             version="0.8.1",
             image="kasprio/kaspr:0.8.1-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),
         KasprVersion(
             operator_version="0.16.0",


### PR DESCRIPTION
Update package __version__ to 0.16.2. Add a new KasprVersion entry for kasprio/kaspr:0.8.2-alpha (operator_version 0.16.0) and make it the default; mark the existing 0.8.1 entry as non-default.