### PR TITLE
Support for `KasprJoin` custom resource type

### DIFF
--- a/crds/kasprjoin.crd.yaml
+++ b/crds/kasprjoin.crd.yaml
@@ -1,0 +1,78 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kasprjoins.kaspr.io
+spec:
+  scope: Namespaced
+  group: kaspr.io
+  names:
+    kind: KasprJoin
+    plural: kasprjoins
+    singular: kasprjoin
+    shortNames:
+      - kjoin
+      - kj
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                name:
+                  type: string
+                  description: The name of the key join.
+                description:
+                  type: string
+                  description: A short description of what this key join does.
+                leftTable:
+                  type: string
+                  description: >
+                    Name of the left-side KasprTable resource.
+                    This is the "driving" table whose changes trigger FK extraction.
+                    Must belong to the same KasprApp (same kaspr.io/app label).
+                rightTable:
+                  type: string
+                  description: >
+                    Name of the right-side KasprTable resource (the "lookup" table).
+                    Must belong to the same KasprApp (same kaspr.io/app label).
+                extractor:
+                  type: object
+                  description: >
+                    Python function that extracts the join key from left-table values.
+                    The returned value is used to look up the corresponding record
+                    in the right table.
+                  properties:
+                    entrypoint:
+                      type: string
+                      description: Name of the function to run.
+                    python:
+                      type: string
+                      description: Python code defining the extractor function.
+                  required:
+                    - python
+                type:
+                  type: string
+                  description: >
+                    Join semantics. "inner" skips emission when right side is None.
+                    "left" emits JoinedValue with right=None when no match exists.
+                  enum: ["inner", "left"]
+                  default: "inner"
+                outputChannel:
+                  type: string
+                  description: >
+                    Name of the output channel for joined results.
+                    KasprAgents reference this via input.channel.name.
+                    Defaults to "{name}-channel" if not specified.
+              required:
+                - leftTable
+                - rightTable
+                - extractor
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true

--- a/crds/kasprjoin.crd.yaml
+++ b/crds/kasprjoin.crd.yaml
@@ -34,7 +34,7 @@ spec:
                   type: string
                   description: >
                     Name of the left-side KasprTable resource.
-                    This is the "driving" table whose changes trigger FK extraction.
+                    This is the "driving" table whose changes trigger key extraction.
                     Must belong to the same KasprApp (same kaspr.io/app label).
                 rightTable:
                   type: string

--- a/docs/design/join-crd-design.md
+++ b/docs/design/join-crd-design.md
@@ -1,0 +1,1037 @@
+# Design Proposal: Join Support via Dedicated `KasprJoin` CRD
+
+> **Status:** Draft  
+> **Date:** 2025-04-01  
+> **Faust Feature:** `Table.key_join()` (KIP-213 subscription/response protocol)  
+> **Faust Version:** ≥ 1.17.10 (branch: `fk-join`)
+
+---
+
+## Table of Contents
+
+1. [Summary](#summary)
+2. [Background: Faust Key Join](#background-faust-key-join)
+3. [Design Goals](#design-goals)
+4. [Proposed CRD Design: `KasprJoin`](#proposed-crd-design-kasprjoin)
+5. [CRD Schema (OpenAPI)](#crd-schema-openapi)
+6. [End-to-End Example](#end-to-end-example)
+7. [Implementation Plan: Kaspr-Operator](#implementation-plan-kaspr-operator)
+8. [Implementation Plan: Kaspr (Runtime)](#implementation-plan-kaspr-runtime)
+9. [Implementation Plan: Helm & Docs](#implementation-plan-helm--docs)
+10. [Alternatives Considered](#alternatives-considered)
+11. [Open Questions](#open-questions)
+
+---
+
+## Summary
+
+Faust recently implemented distributed table-to-table key joins via a subscription/response protocol (inspired by Kafka Streams KIP-213). This allows two differently-keyed, differently-partitioned tables to be joined reactively — whenever either side changes, a `JoinedValue(left, right)` is emitted to a channel that can be consumed by an agent.
+
+This proposal defines a **dedicated `KasprJoin` CRD** to expose this capability to end-users. A key join is a first-class concept with its own lifecycle, validation, status, and monitoring — making a standalone resource the most natural and user-friendly approach. Users declare joins entirely in YAML and deploy them to Kubernetes without writing Python code (beyond the small extractor function).
+
+---
+
+## Background: Faust Key Join
+
+### How It Works (Internal Protocol)
+
+```
+Left Table Change                              Right Table Change
+     │                                              │
+     ▼                                              ▼
+Extract FK from left value              Prefix-scan subscription store
+     │                                    for all subscribers of this key
+     ▼                                              │
+Send subscription message ──────┐                   │
+  (keyed by FK, contains        │                   │
+   left_pk + hash of left val)  │                   │
+                                ▼                   ▼
+              ┌─────────────────────────────────┐
+              │  Subscription-Registration Topic │
+              │  (co-partitioned with right table)│
+              └──────────────┬──────────────────┘
+                             │
+                             ▼
+              Right-side task stores subscription
+              in subscription store (FK, left_pk)
+              then looks up current right value
+                             │
+                             ▼
+              ┌─────────────────────────────────┐
+              │  Subscription-Response Topic     │
+              │  (co-partitioned with left table)│
+              └──────────────┬──────────────────┘
+                             │
+                             ▼
+              Left-side task receives response,
+              validates hash (discard if stale),
+              emits JoinedValue(left, right)
+              to output channel
+```
+
+### Faust Python API
+
+```python
+# Two tables with different keys
+orders_table = app.Table('orders', ...)       # keyed by order_id
+products_table = app.Table('products', ...)   # keyed by product_id
+
+# Join orders → products by extracting product_id from order values
+joined_channel = orders_table.key_join(
+    products_table,
+    extractor=lambda order: order.get('product_id'),
+    inner=True,  # skip if right side is None
+)
+
+# Consume joined results
+@app.agent(joined_channel)
+async def process_joined(joined_values):
+    async for joined in joined_values:
+        order = joined.left      # the order record
+        product = joined.right   # the matching product record
+```
+
+### Key Properties
+
+- **No co-partitioning required** — left and right tables can have different keys, different partition counts.
+- **Reactive** — changes on either side trigger re-emission of join results.
+- **Internal topics are auto-created** — `{app}-{left}-{right}-subscription-registration` and `{app}-{left}-{right}-subscription-response`.
+- **Internal stores are auto-created** — subscription store + previous-FK tracker.
+- **Hash-based staleness detection** — prevents stale responses after rapid left-side updates.
+- **Supports inner join** (`inner=True`, default) and **left join** (`inner=False`) semantics.
+
+---
+
+## Design Goals
+
+1. **Declarative YAML** — Users define key joins entirely in CRD YAML, no Python beyond the `extractor` function.
+2. **First-class resource** — A key join is its own CRD with dedicated lifecycle, status, and validation — easy to reason about, create, delete, and monitor independently.
+3. **Consistent with existing patterns** — Follow the same CRD conventions as `KasprAgent`, `KasprTable`, `KasprTask` (handler/resource/model/schema architecture).
+4. **Table references** — Joins reference existing `KasprTable` resources by name, validated by the operator.
+5. **Agent-as-consumer** — The joined channel is consumed by a `KasprAgent` via `input.channel`.
+
+---
+
+## Proposed CRD Design: `KasprJoin`
+
+A `KasprJoin` resource declares a reactive join between two `KasprTable` resources within the same `KasprApp`. It produces a named output channel that `KasprAgent` resources can consume.
+
+### Resource Definition
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprJoin
+metadata:
+  name: orders-products-join
+  namespace: demo
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: orders-products-join
+  description: "Join orders with products by product_id"
+
+  # The left-side table (the "driving" side of the join)
+  leftTable: orders
+
+  # The right-side table (the "lookup" side of the join)
+  rightTable: products
+
+  # Python function to extract the join key from left-table values.
+  # The returned value is used to look up the corresponding record
+  # in the right table.
+  extractor:
+    entrypoint: get_product_id
+    python: |
+      def get_product_id(value):
+          return value.get("product_id")
+
+  # Join semantics: "inner" (default) or "left"
+  #   inner: skip emission when right side is None
+  #   left: emit with right=None when no match exists
+  type: inner
+
+  # Name of the output channel for joined results.
+  # KasprAgents reference this via input.channel.name.
+  # Defaults to "{name}-channel" if not specified.
+  outputChannel: orders-products-joined
+```
+
+### Status Subresource
+
+```yaml
+status:
+  app:
+    name: order-system
+    status: AppFound        # or AppNotFound
+  leftTable:
+    name: orders
+    status: TableFound      # or TableNotFound
+  rightTable:
+    name: products
+    status: TableFound      # or TableNotFound
+  configMap: orders-products-join
+  hash: "abc123..."
+```
+
+### Key Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **Dedicated CRD** | A join is a first-class data flow concept — it has its own inputs (two tables), logic (extractor), semantics (inner/left), output (channel), and lifecycle. Users can `kubectl get kasprjoin` to see all joins, inspect their status, and manage them independently. |
+| **Both `leftTable` and `rightTable` are explicit** | Unlike embedding on KasprTable where left is implicit, declaring both sides makes the resource self-describing. A user reading the YAML instantly understands the full join topology. |
+| **`extractor` uses the standard `CodeSpec` pattern** | Reuses the existing `entrypoint` + `python` pattern from agents, tasks, and operations. No new code execution patterns needed. |
+| **`outputChannel` is optional with a sensible default** | Reduces boilerplate for simple cases while allowing override for explicit naming. Default: `{name}-channel`. |
+| **`type` field for join semantics** | Maps directly to Faust's `inner` parameter. `"inner"` (default) = skip when right is None; `"left"` = emit with right=None. |
+
+---
+
+## CRD Schema (OpenAPI)
+
+File: `crds/kasprjoin.crd.yaml`
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kasprjoins.kaspr.io
+spec:
+  scope: Namespaced
+  group: kaspr.io
+  names:
+    kind: KasprJoin
+    plural: kasprjoins
+    singular: kasprjoin
+    shortNames:
+      - kjoin
+      - kj
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                name:
+                  type: string
+                  description: The name of the key join.
+                description:
+                  type: string
+                  description: A short description of what this key join does.
+                leftTable:
+                  type: string
+                  description: >
+                    Name of the left-side KasprTable resource.
+                    This is the "driving" table whose changes trigger FK extraction.
+                    Must belong to the same KasprApp (same kaspr.io/app label).
+                rightTable:
+                  type: string
+                  description: >
+                    Name of the right-side KasprTable resource (the "lookup" table).
+                    Must belong to the same KasprApp (same kaspr.io/app label).
+                extractor:
+                  type: object
+                  description: >
+                    Python function that extracts the join key from left-table values.
+                    The returned value is used to look up the corresponding record
+                    in the right table.
+                  properties:
+                    entrypoint:
+                      type: string
+                      description: Name of the function to run.
+                    python:
+                      type: string
+                      description: Python code defining the extractor function.
+                  required:
+                    - python
+                type:
+                  type: string
+                  description: >
+                    Join semantics. "inner" skips emission when right side is None.
+                    "left" emits JoinedValue with right=None when no match exists.
+                  enum: ["inner", "left"]
+                  default: "inner"
+                outputChannel:
+                  type: string
+                  description: >
+                    Name of the output channel for joined results.
+                    KasprAgents reference this via input.channel.name.
+                    Defaults to "{name}-channel" if not specified.
+              required:
+                - name
+                - leftTable
+                - rightTable
+                - extractor
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+```
+
+---
+
+## End-to-End Example
+
+### Scenario: Order Enrichment with Product Data
+
+Four CRD types deployed together — `KasprApp`, `KasprTable` × 2, `KasprJoin`, `KasprAgent` × 3.
+
+#### 1. KasprApp
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprApp
+metadata:
+  name: order-system
+  namespace: demo
+spec:
+  replicas: 3
+  bootstrapServers: kafka-bootstrap:9092
+  config:
+    topicPartitions: 6
+    topicReplicationFactor: 3
+  storage:
+    size: 5Gi
+```
+
+#### 2. Products Table
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: products
+  namespace: demo
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: products
+  description: "Product catalog keyed by product_id"
+  partitions: 6
+```
+
+#### 3. Orders Table
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: orders
+  namespace: demo
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: orders
+  description: "Orders keyed by order_id"
+  partitions: 6
+```
+
+#### 4. Key Join (dedicated resource)
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprJoin
+metadata:
+  name: orders-products-join
+  namespace: demo
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: orders-products-join
+  description: "Join orders with products by product_id"
+  leftTable: orders
+  rightTable: products
+  extractor:
+    entrypoint: get_product_id
+    python: |
+      def get_product_id(order):
+          return order.get("product_id")
+  type: inner
+  outputChannel: orders-products-joined
+```
+
+#### 5. Agents — Ingest + Process Joined Stream
+
+```yaml
+# Agent that ingests raw orders into the orders table
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: ingest-orders
+  namespace: demo
+  labels:
+    kaspr.io/app: order-system
+spec:
+  input:
+    topic:
+      name: raw-orders
+  processors:
+    pipeline:
+      - store-order
+    init:
+      python: |
+        app = context["app"]
+    operations:
+      - name: store-order
+        tables:
+          - name: orders
+            paramName: orders_table
+        map:
+          entrypoint: store
+          python: |
+            def store(value, orders_table):
+                order_id = value.get("order_id")
+                orders_table[order_id] = value
+                return value
+---
+# Agent that ingests products into the products table
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: ingest-products
+  namespace: demo
+  labels:
+    kaspr.io/app: order-system
+spec:
+  input:
+    topic:
+      name: raw-products
+  processors:
+    pipeline:
+      - store-product
+    init:
+      python: |
+        app = context["app"]
+    operations:
+      - name: store-product
+        tables:
+          - name: products
+            paramName: products_table
+        map:
+          entrypoint: store
+          python: |
+            def store(value, products_table):
+                product_id = value.get("product_id")
+                products_table[product_id] = value
+                return value
+---
+# Agent that processes the joined order+product stream
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: process-enriched-orders
+  namespace: demo
+  labels:
+    kaspr.io/app: order-system
+spec:
+  description: "Processes joined order+product records from key join"
+  input:
+    channel:
+      name: orders-products-joined
+  output:
+    topics:
+      - name: enriched-orders
+        keySelector:
+          python: |
+            def get_key(value):
+                return value.get("order_id")
+  processors:
+    pipeline:
+      - enrich
+    init:
+      python: |
+        from datetime import datetime, timezone
+    operations:
+      - name: enrich
+        map:
+          entrypoint: enrich_order
+          python: |
+            def enrich_order(value):
+                """
+                value is a JoinedValue dict:
+                  {"left": <order>, "right": <product>}
+                """
+                order = value["left"]
+                product = value["right"]
+                return {
+                    "order_id": order.get("order_id"),
+                    "product_id": order.get("product_id"),
+                    "quantity": order.get("quantity"),
+                    "product_name": product.get("name"),
+                    "unit_price": product.get("price"),
+                    "total": product.get("price", 0) * order.get("quantity", 0),
+                    "enriched_at": datetime.now(timezone.utc).isoformat()
+                }
+```
+
+### What Happens at Runtime
+
+1. **Operator** reconciles the `KasprJoin` resource `orders-products-join`. It:
+   - Validates that `leftTable: orders` and `rightTable: products` exist as `KasprTable` resources with the same `kaspr.io/app: order-system` label.
+   - Serializes the key join spec into a ConfigMap (`orders-products-join`).
+   - Updates status with table validation results and config map reference.
+   - Triggers a reconciliation of the parent `KasprApp` so the app picks up the new join.
+
+2. **Kaspr** `AppBuilder` loads all component definitions. When it encounters the key join spec, it:
+   - Resolves `leftTable: orders` → the `orders` Faust table instance.
+   - Resolves `rightTable: products` → the `products` Faust table instance.
+   - Compiles the `extractor` Python code → a callable.
+   - Calls `orders_table.key_join(products_table, extractor=..., inner=True)`.
+   - Registers the returned channel under the name `orders-products-joined`.
+
+3. **Kaspr** `AppBuilder` loads agent definitions. The `process-enriched-orders` agent has `input.channel.name: orders-products-joined`, which resolves to the key join's output channel.
+
+4. **Faust** `KeyJoinProcessor` starts as a service:
+   - Creates internal topics: `order-system-orders-products-subscription-registration`, `order-system-orders-products-subscription-response`.
+   - Creates internal stores: `orders-products-subscriptions`, `orders-products-previous-fk`.
+   - Registers callbacks on both tables.
+
+5. When an order is ingested → `_on_left_table_change()` fires → subscription message sent → right side responds → `JoinedValue` emitted to channel → `process-enriched-orders` agent processes it.
+
+6. When a product is updated → `_on_right_table_change()` fires → all subscribers notified → updated `JoinedValue` emitted for each affected order.
+
+---
+
+## Implementation Plan: Kaspr-Operator
+
+The operator changes follow the exact same pattern used for `KasprTask` (the most recently added CRD).
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `crds/kasprjoin.crd.yaml` | OpenAPI CRD definition (see [CRD Schema](#crd-schema-openapi) above) |
+| `kaspr/types/models/kasprjoin_spec.py` | Spec model (`KasprJoinSpec`) |
+| `kaspr/types/models/kasprjoin_resources.py` | Resource naming scheme (`KasprJoinResources`) |
+| `kaspr/types/schemas/kasprjoin_spec.py` | Marshmallow schema (`KasprJoinSpecSchema`) |
+| `kaspr/resources/kasprjoin.py` | Resource class (`KasprJoin(BaseAppComponent)`) |
+| `kaspr/handlers/kasprjoin.py` | Kopf handlers (reconcile, monitor, full sync) |
+| `examples/join/basic.yaml` | Example CRD manifests |
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `kaspr/types/models/component.py` | Add `joins: Optional[List[KasprJoinSpec]]` to `KasprAppComponents` |
+| `kaspr/types/schemas/component.py` | Add `joins` field to `KasprAppComponentsSchema` |
+| `kaspr/types/models/__init__.py` | Export new model types |
+| `kaspr/types/schemas/__init__.py` | Export new schema types |
+| `kaspr/resources/__init__.py` | Export `KasprJoin` |
+
+### Model: `kasprjoin_spec.py`
+
+```python
+from typing import Optional
+from kaspr.types.base import BaseModel
+from kaspr.types.models.code import CodeSpec
+
+
+class KasprJoinSpec(BaseModel):
+    """KasprJoin CRD spec"""
+
+    name: str
+    description: Optional[str]
+    left_table: str
+    right_table: str
+    extractor: CodeSpec
+    join_type: Optional[str]        # "inner" (default) or "left"
+    output_channel: Optional[str]   # Named channel for joined output
+```
+
+### Resources: `kasprjoin_resources.py`
+
+```python
+class KasprJoinResources:
+    """Naming scheme for KasprJoin managed resources."""
+
+    @classmethod
+    def component_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def config_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def volume_mount_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def service_account_name(cls, cluster_name: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def service_name(cls, cluster_name: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def qualified_service_name(cls, cluster_name: str, namespace: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def url(cls, cluster_name: str, namespace: str, port: int):
+        raise NotImplementedError()
+
+    @classmethod
+    def settings_secret_name(cls, cluster_name: str):
+        raise NotImplementedError()
+```
+
+### Schema: `kasprjoin_spec.py`
+
+```python
+from marshmallow import fields, post_dump
+from kaspr.types.base import BaseSchema
+from kaspr.types.models.kasprjoin_spec import KasprJoinSpec
+from kaspr.types.schemas.code import CodeSpecSchema
+from kaspr.utils.helpers import camel_to_snake
+
+
+class KasprJoinSpecSchema(BaseSchema):
+    __model__ = KasprJoinSpec
+
+    name = fields.String(data_key="name", required=True)
+    description = fields.String(
+        data_key="description", allow_none=True, load_default=None
+    )
+    left_table = fields.String(data_key="leftTable", required=True)
+    right_table = fields.String(data_key="rightTable", required=True)
+    extractor = fields.Nested(
+        CodeSpecSchema(), data_key="extractor", required=True
+    )
+    join_type = fields.String(
+        data_key="type", allow_none=True, load_default="inner"
+    )
+    output_channel = fields.String(
+        data_key="outputChannel", allow_none=True, load_default=None
+    )
+
+    @post_dump
+    def camel_to_snake_dump(self, data, **kwargs):
+        return camel_to_snake(data)
+```
+
+### Resource: `kasprjoin.py`
+
+```python
+from typing import Dict
+from kaspr.types.models import KasprJoinSpec, KasprJoinResources
+from kaspr.utils.objects import cached_property
+from kaspr.resources.appcomponent import BaseAppComponent
+from kaspr.types.models import KasprAppComponents
+
+
+class KasprJoin(BaseAppComponent):
+    """Kaspr Key Join kubernetes resource."""
+
+    KIND = "KasprJoin"
+    COMPONENT_TYPE = "join"
+    PLURAL_NAME = "kasprjoins"
+    kaspr_resource = KasprJoinResources
+
+    spec: KasprJoinSpec
+
+    @classmethod
+    def from_spec(
+        cls,
+        name: str,
+        kind: str,
+        namespace: str,
+        spec: KasprJoinSpec,
+        labels: Dict[str, str] = None,
+    ) -> "KasprJoin":
+        join_resource = KasprJoin(name, kind, namespace, cls.KIND, labels)
+        join_resource.spec = spec
+        join_resource.spec.name = name
+        join_resource.config_map_name = cls.kaspr_resource.config_name(name)
+        join_resource.volume_mount_name = cls.kaspr_resource.volume_mount_name(name)
+        return join_resource
+
+    @classmethod
+    def default(cls) -> "KasprJoin":
+        return KasprJoin(
+            name="default",
+            kind=cls.KIND,
+            namespace=None,
+            component_type=cls.COMPONENT_TYPE,
+        )
+
+    @cached_property
+    def app_components(self) -> KasprAppComponents:
+        return KasprAppComponents(joins=[self.spec])
+```
+
+### Handler: `kasprjoin.py`
+
+```python
+import asyncio
+import kopf
+import logging
+from collections import defaultdict
+from typing import Dict
+from benedict import benedict
+from kaspr.types.schemas import KasprJoinSpecSchema
+from kaspr.types.models import KasprJoinSpec
+from kaspr.resources import KasprJoin, KasprApp, KasprTable
+from kaspr.sensors import SensorDelegate
+
+KIND = "KasprJoin"
+APP_NOT_FOUND = "AppNotFound"
+APP_FOUND = "AppFound"
+LEFT_TABLE_NOT_FOUND = "LeftTableNotFound"
+LEFT_TABLE_FOUND = "LeftTableFound"
+RIGHT_TABLE_NOT_FOUND = "RightTableNotFound"
+RIGHT_TABLE_FOUND = "RightTableFound"
+
+patch_request_queues: Dict[str, asyncio.Queue] = defaultdict(asyncio.Queue)
+
+
+def get_sensor() -> SensorDelegate:
+    return getattr(KasprJoin, 'sensor', None)
+
+
+class TimerLogFilter(logging.Filter):
+    def filter(self, record):
+        return "Timer " not in record.getMessage()
+
+
+kopf_logger = logging.getLogger("kopf.objects")
+kopf_logger.addFilter(TimerLogFilter())
+
+
+@kopf.on.resume(kind=KIND)
+@kopf.on.create(kind=KIND)
+@kopf.on.update(kind=KIND)
+async def reconciliation(
+    body, spec, name, namespace, logger, labels, patch, annotations, **kwargs
+):
+    """Reconcile KasprJoin resources."""
+    spec_model: KasprJoinSpec = KasprJoinSpecSchema().load(spec)
+    join_resource = KasprJoin.from_spec(name, KIND, namespace, spec_model, dict(labels))
+    app = await KasprApp.default().fetch(join_resource.app_name, namespace)
+    await join_resource.create()
+
+    # Validate referenced tables exist
+    left_table = await KasprTable.default().fetch(spec_model.left_table, namespace)
+    right_table = await KasprTable.default().fetch(spec_model.right_table, namespace)
+
+    patch.status.update({
+        "app": {
+            "name": join_resource.app_name,
+            "status": APP_FOUND if app else APP_NOT_FOUND,
+        },
+        "leftTable": {
+            "name": spec_model.left_table,
+            "status": LEFT_TABLE_FOUND if left_table else LEFT_TABLE_NOT_FOUND,
+        },
+        "rightTable": {
+            "name": spec_model.right_table,
+            "status": RIGHT_TABLE_FOUND if right_table else RIGHT_TABLE_NOT_FOUND,
+        },
+        "configMap": join_resource.config_map_name,
+        "hash": join_resource.hash,
+    })
+
+    if app is None:
+        kopf.warn(body, reason=APP_NOT_FOUND,
+                  message=f"KasprApp `{join_resource.app_name}` not found in `{namespace or 'default'}` namespace.")
+    if left_table is None:
+        kopf.warn(body, reason=LEFT_TABLE_NOT_FOUND,
+                  message=f"KasprTable `{spec_model.left_table}` not found in `{namespace or 'default'}` namespace.")
+    if right_table is None:
+        kopf.warn(body, reason=RIGHT_TABLE_NOT_FOUND,
+                  message=f"KasprTable `{spec_model.right_table}` not found in `{namespace or 'default'}` namespace.")
+
+
+@kopf.timer(KIND, interval=1)
+async def patch_resource(name, patch, **kwargs):
+    queue = patch_request_queues[name]
+    def set_patch(request):
+        fields = request["field"].split(".")
+        _patch = patch
+        for field in fields:
+            _patch = getattr(_patch, field)
+        _patch.update(request["value"])
+    while not queue.empty():
+        request = queue.get_nowait()
+        if isinstance(request, list):
+            for req in request:
+                set_patch(req)
+        else:
+            set_patch(request)
+
+
+@kopf.daemon(kind=KIND, cancellation_backoff=2.0, cancellation_timeout=5.0, initial_delay=5.0)
+async def monitor_join(
+    stopped, name, body, spec, meta, labels, status, namespace, patch, logger, **kwargs
+):
+    """Monitor KasprJoin resources for table availability."""
+    while not stopped:
+        try:
+            _status = benedict(status, keyattr_dynamic=True)
+            _status_updates = benedict(keyattr_dynamic=True)
+            spec_model: KasprJoinSpec = KasprJoinSpecSchema().load(spec)
+            join_resource = KasprJoin.from_spec(name, KIND, namespace, spec_model, dict(labels))
+
+            # Check app existence
+            app = await KasprApp.default().fetch(join_resource.app_name, namespace)
+            if app is None and _status.app.status == APP_FOUND:
+                kopf.warn(body, reason=APP_NOT_FOUND,
+                          message=f"KasprApp `{join_resource.app_name}` not found.")
+                _status_updates.app.status = APP_NOT_FOUND
+            elif app and _status.app.status == APP_NOT_FOUND:
+                kopf.event(body, type="Normal", reason=APP_FOUND,
+                           message=f"KasprApp `{join_resource.app_name}` found.")
+                _status_updates.app.status = APP_FOUND
+
+            # Check left table existence
+            left_table = await KasprTable.default().fetch(spec_model.left_table, namespace)
+            if left_table is None and _status.get("leftTable", {}).get("status") == LEFT_TABLE_FOUND:
+                kopf.warn(body, reason=LEFT_TABLE_NOT_FOUND,
+                          message=f"KasprTable `{spec_model.left_table}` not found.")
+                _status_updates.leftTable.status = LEFT_TABLE_NOT_FOUND
+            elif left_table and _status.get("leftTable", {}).get("status") == LEFT_TABLE_NOT_FOUND:
+                kopf.event(body, type="Normal", reason=LEFT_TABLE_FOUND,
+                           message=f"KasprTable `{spec_model.left_table}` found.")
+                _status_updates.leftTable.status = LEFT_TABLE_FOUND
+
+            # Check right table existence
+            right_table = await KasprTable.default().fetch(spec_model.right_table, namespace)
+            if right_table is None and _status.get("rightTable", {}).get("status") == RIGHT_TABLE_FOUND:
+                kopf.warn(body, reason=RIGHT_TABLE_NOT_FOUND,
+                          message=f"KasprTable `{spec_model.right_table}` not found.")
+                _status_updates.rightTable.status = RIGHT_TABLE_NOT_FOUND
+            elif right_table and _status.get("rightTable", {}).get("status") == RIGHT_TABLE_NOT_FOUND:
+                kopf.event(body, type="Normal", reason=RIGHT_TABLE_FOUND,
+                           message=f"KasprTable `{spec_model.right_table}` found.")
+                _status_updates.rightTable.status = RIGHT_TABLE_FOUND
+
+            if _status_updates:
+                await patch_request_queues[name].put(
+                    [{"field": "status", "value": _status_updates}]
+                )
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            logger.info("Monitoring stopped.")
+            break
+        except Exception as e:
+            logger.error(f"Unexpected error during monitoring: {e}")
+            logger.exception(e)
+
+
+@kopf.timer(KIND, initial_delay=5.0, interval=60.0, backoff=10.0)
+async def reconcile(name, spec, namespace, labels, logger, **kwargs):
+    """Full sync."""
+    sensor = get_sensor()
+    success = True
+    error = None
+    try:
+        spec_model: KasprJoinSpec = KasprJoinSpecSchema().load(spec)
+        join_resource = KasprJoin.from_spec(name, KIND, namespace, spec_model, dict(labels))
+        sensor_state = sensor.on_reconcile_start(join_resource.app_name, name, namespace, 0, "timer")
+        logger.debug(f"Reconciling {KIND}/{name} in {namespace} namespace.")
+        await join_resource.synchronize()
+        logger.debug(f"Reconciled {KIND}/{name} in {namespace} namespace.")
+    except Exception as e:
+        success = False
+        error = e
+        logger.error(f"Unexpected error during reconciliation: {e}")
+        logger.exception(e)
+    finally:
+        sensor.on_reconcile_complete(join_resource.app_name, name, namespace, sensor_state, success, error)
+```
+
+### Component Model Change
+
+```python
+# kaspr/types/models/component.py
+class KasprAppComponents(BaseModel):
+    agents: Optional[List[KasprAgentSpec]]
+    webviews: Optional[List[KasprWebViewSpec]]
+    tables: Optional[List[KasprTableSpec]]
+    tasks: Optional[List[KasprTaskSpec]]
+    joins: Optional[List[KasprJoinSpec]]  # NEW
+```
+
+### Component Schema Change
+
+```python
+# kaspr/types/schemas/component.py
+class KasprAppComponentsSchema(BaseSchema):
+    __model__ = KasprAppComponents
+
+    # ...existing fields...
+    joins = fields.List(
+        fields.Nested(KasprJoinSpecSchema()),
+        data_key="joins",
+        required=False,
+        load_default=[],
+    )
+```
+
+---
+
+## Implementation Plan: Kaspr (Runtime)
+
+The kaspr runtime needs to understand key join definitions and wire them up during app build.
+
+### Files to Change
+
+| File | Change |
+|------|--------|
+| `kaspr/types/models/join/` | New directory with `JoinSpec` model (mirrors operator's model) |
+| `kaspr/types/schemas/join/` | New directory with `JoinSpecSchema` (mirrors operator's schema) |
+| `kaspr/core/builder.py` | After building tables, iterate key join specs, call `left_table.key_join()`, register output channels |
+| `kaspr/core/app.py` | Add `_named_channels: Dict[str, ChannelT]` registry + `register_named_channel()` + `resolve_channel()` |
+| `kaspr/types/models/agent/input.py` | Update `prepare_channel()` to resolve named channels from `app._named_channels` |
+
+### New Model: `JoinSpec`
+
+```python
+# kaspr/types/models/join/join.py
+class JoinSpec(SpecComponent):
+    name: str
+    left_table: str
+    right_table: str
+    extractor: PyCode
+    join_type: Optional[str]        # "inner" or "left"
+    output_channel: Optional[str]
+
+    app: KasprAppT = None
+```
+
+### Builder Changes
+
+```python
+# kaspr/core/builder.py (conceptual additions to build())
+def build(self):
+    for app in self.apps:
+        app.agents
+        app.webviews
+        app.tables    # creates all tables first
+        app.tasks
+
+        # NEW: After tables are created, wire up key joins
+        for join_spec in app.joins_spec:
+            self._wire_key_join(join_spec)
+
+def _wire_key_join(self, join_spec):
+    left_table = self.app.tables[join_spec.left_table]
+    right_table = self.app.tables[join_spec.right_table]
+    extractor = join_spec.extractor.func
+    inner = (join_spec.join_type or "inner") == "inner"
+
+    channel = left_table.key_join(right_table, extractor=extractor, inner=inner)
+
+    channel_name = join_spec.output_channel or f"{join_spec.name}-channel"
+    self.app.register_named_channel(channel_name, channel)
+```
+
+---
+
+## Implementation Plan: Helm & Docs
+
+### Helm
+
+1. **New CRD file:** Copy `kasprjoin.crd.yaml` to `kaspr-helm/charts/operator/crds/kasprjoin.crd.yaml`.
+2. **Resources template:** Add `charts/resources/templates/join.yaml` for rendering `KasprJoin` from values.
+3. **Values example:** Add key join examples to `charts/resources/values.yaml`.
+
+### Documentation
+
+1. **New page:** `pages/docs/user-guide/key-joins.mdx` — Dedicated guide covering:
+   - What key joins are and when to use them
+   - The subscription/response protocol (conceptual, with diagram)
+   - Full YAML walkthrough with order/product example
+   - Inner vs left join semantics
+   - How `JoinedValue` is structured (`{"left": ..., "right": ...}`)
+   - Connecting a `KasprAgent` to the join's output channel
+   - Performance considerations (subscription store size, topic partitioning)
+2. **Update:** `pages/docs/user-guide/agents.mdx` — Add section on using channel input from key joins.
+3. **Update:** `pages/docs/user-guide/concepts.mdx` — Add key joins to concepts overview with architecture diagram.
+4. **New API reference entry:** Add `KasprJoin` to `pages/docs/api-reference/v1alpha1.mdx`.
+
+---
+
+## Alternatives Considered
+
+### Alternative A: `keyJoin` Field on `KasprTable`
+
+Embed the join config as a `keyJoin` field on the left-side `KasprTable` CRD:
+
+```yaml
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: orders
+spec:
+  name: orders
+  partitions: 6
+  keyJoin:
+    rightTable: products
+    extractor:
+      python: |
+        def get_key(value):
+            return value.get("product_id")
+    type: inner
+    outputChannel: orders-products-joined
+```
+
+**Pros:** Fewer total CRDs; join is co-located with the left table definition; no new handler/resource/model files needed.
+
+**Cons:**
+- **Harder to reason about** — users must inspect each table to discover joins; `kubectl get kasprtables` doesn't show which tables have joins.
+- **Overloads the table concept** — a table is a storage abstraction; a join is a data flow concept. Mixing them makes each less clear.
+- **Lifecycle coupling** — updating the join config requires modifying the table resource, which may trigger unrelated reconciliation. Deleting a table deletes its joins implicitly.
+- **Multiple joins from one table** — requires `joins` array, making the table spec complex. With a dedicated CRD, you simply create additional `KasprJoin` resources.
+- **Status complexity** — table status must now include join-specific health (subscription lag, table reference validation), muddying its semantics.
+
+**Verdict:** Not recommended. The dedicated CRD is cleaner for users, operators, and future extensibility.
+
+### Alternative B: `keyJoin` on `KasprAgent` Input
+
+Define the join inline on the agent that consumes it:
+
+```yaml
+spec:
+  input:
+    keyJoin:
+      leftTable: orders
+      rightTable: products
+      extractor: ...
+```
+
+**Pros:** Join definition is co-located with the consumer.  
+**Cons:** Ties the join lifecycle to the agent; if multiple agents need the same join, the config is duplicated; conceptually the join is between tables, not owned by an agent.
+
+**Verdict:** Not recommended. The join is a table-level relationship, not an agent-level concern.
+
+### Alternative C: Implicit Channel Name
+
+Don't require `outputChannel` — always auto-generate the channel name as `{name}-channel`.
+
+**Pros:** Less config.  
+**Cons:** Users must know the naming convention; less explicit.
+
+**Verdict:** Use auto-generated default but allow override via `outputChannel`. This is the recommended approach (already part of the proposal).
+
+---
+
+## Open Questions
+
+1. **Multiple joins from one table** — A table could be the left side of multiple joins (e.g., orders → products AND orders → customers). The dedicated CRD handles this naturally: create one `KasprJoin` per relationship. No schema changes needed.
+
+2. **Key join status/health** — Should the `KasprJoin` status include join health metrics (subscription topic lag, response latency, etc.)? Useful for monitoring but adds complexity. Recommend basic table-reference validation for v1, metrics in v2.
+
+3. **Cross-namespace joins** — Should `leftTable`/`rightTable` support referencing tables in a different namespace? Not currently supported by the operator's label-based ownership model. Recommend keeping same-namespace only.
+
+4. **JoinedValue format** — Faust emits `JoinedValue(left=..., right=...)` as a named tuple. When serialized for the processor pipeline, this becomes `{"left": ..., "right": ...}`. Need to verify the exact serialization format in kaspr's `PyCode` execution context.
+
+5. **Table ordering at build time** — The builder must ensure tables are created before key joins are wired. A two-pass approach (build all tables first, then wire joins) is recommended and matches the current builder pattern.
+
+6. **Short name convention** — Recommended short names for `kubectl`: `kjoin` and `kj` (e.g., `kubectl get kjoin`). Plural name: `kasprjoins`.
+
+7. **Cascading reconciliation** — When a `KasprJoin` is created/updated/deleted, the parent `KasprApp` needs to be reconciled to pick up the change. This follows the same pattern as other child resources (agents, tables, tasks) triggering app reconciliation via label selectors.

--- a/docs/design/join-implementation-plan.md
+++ b/docs/design/join-implementation-plan.md
@@ -1,0 +1,822 @@
+# KasprJoin Implementation Plan
+
+> **Design Doc:** [join-crd-design.md](./join-crd-design.md)  
+> **Date:** 2025-04-01  
+> **Status:** Draft
+
+---
+
+## Overview
+
+This document breaks the `KasprJoin` CRD feature into **6 incremental phases**, each producing a testable, reviewable deliverable. Phases are ordered by dependency — each phase builds on the previous and can be merged independently.
+
+### Repository Map
+
+| Repo | Role | Branch |
+|------|------|--------|
+| `faust` | Stream processing framework (key join already implemented) | `fk-join` (merged to master) |
+| `kaspr-operator` | Kubernetes operator — CRD, types, handlers, resources | `feature/kasprjoin` |
+| `kaspr` | Runtime — builder, models, schemas, channel wiring | `feature/kasprjoin` |
+| `kaspr-helm` | Helm charts — CRD + resource templates | `feature/kasprjoin` |
+| `kaspr-docs` | Documentation — user guide, API reference | `feature/kasprjoin` |
+
+### Phase Dependency Graph
+
+```
+Phase 1 (Operator Types)
+    │
+    ├── Phase 2 (Operator CRD + Resources + Handlers)
+    │       │
+    │       └── Phase 4 (Helm Charts)
+    │
+    └── Phase 3 (Kaspr Runtime)
+            │
+            └── Phase 5 (Integration Testing)
+                    │
+                    └── Phase 6 (Documentation)
+```
+
+---
+
+## Phase 1: Operator Types (Model + Schema)
+
+**Repo:** `kaspr-operator`  
+**Goal:** Define the data types that all other operator components depend on. This is the foundation.
+
+### Step 1.1 — Create spec model
+
+Create `kaspr/types/models/kasprjoin_spec.py`:
+
+```python
+from typing import Optional
+from kaspr.types.base import BaseModel
+from kaspr.types.models.code import CodeSpec
+
+
+class KasprJoinSpec(BaseModel):
+    """KasprJoin CRD spec"""
+
+    name: str
+    description: Optional[str]
+    left_table: str
+    right_table: str
+    extractor: CodeSpec
+    join_type: Optional[str]        # "inner" (default) or "left"
+    output_channel: Optional[str]   # Named channel for joined output
+```
+
+### Step 1.2 — Create resource naming scheme
+
+Create `kaspr/types/models/kasprjoin_resources.py`:
+
+```python
+class KasprJoinResources:
+    """Naming scheme for KasprJoin managed resources."""
+
+    @classmethod
+    def component_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def config_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def volume_mount_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def service_account_name(cls, cluster_name: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def service_name(cls, cluster_name: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def qualified_service_name(cls, cluster_name: str, namespace: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def url(cls, cluster_name: str, namespace: str, port: int):
+        raise NotImplementedError()
+
+    @classmethod
+    def settings_secret_name(cls, cluster_name: str):
+        raise NotImplementedError()
+```
+
+### Step 1.3 — Create marshmallow schema
+
+Create `kaspr/types/schemas/kasprjoin_spec.py`:
+
+```python
+from marshmallow import fields, post_dump
+from kaspr.types.base import BaseSchema
+from kaspr.types.models.kasprjoin_spec import KasprJoinSpec
+from kaspr.types.schemas.code import CodeSpecSchema
+from kaspr.utils.helpers import camel_to_snake
+
+
+class KasprJoinSpecSchema(BaseSchema):
+    __model__ = KasprJoinSpec
+
+    name = fields.String(data_key="name", required=True)
+    description = fields.String(
+        data_key="description", allow_none=True, load_default=None
+    )
+    left_table = fields.String(data_key="leftTable", required=True)
+    right_table = fields.String(data_key="rightTable", required=True)
+    extractor = fields.Nested(
+        CodeSpecSchema(), data_key="extractor", required=True
+    )
+    join_type = fields.String(
+        data_key="type", allow_none=True, load_default="inner"
+    )
+    output_channel = fields.String(
+        data_key="outputChannel", allow_none=True, load_default=None
+    )
+
+    @post_dump
+    def camel_to_snake_dump(self, data, **kwargs):
+        return camel_to_snake(data)
+```
+
+### Step 1.4 — Register in `__init__.py` exports
+
+**Modify** `kaspr/types/models/__init__.py`:
+- Import and export `KasprJoinSpec`, `KasprJoinResources`
+- Add both to `__all__`
+
+**Modify** `kaspr/types/schemas/__init__.py`:
+- Import and export `KasprJoinSpecSchema`
+- Add to `__all__`
+
+### Step 1.5 — Add to `KasprAppComponents`
+
+**Modify** `kaspr/types/models/component.py`:
+- Import `KasprJoinSpec`
+- Add field: `joins: Optional[List[KasprJoinSpec]]`
+
+**Modify** `kaspr/types/schemas/component.py`:
+- Import `KasprJoinSpecSchema`
+- Add field:
+  ```python
+  joins = fields.List(
+      fields.Nested(KasprJoinSpecSchema()),
+      data_key="joins",
+      required=False,
+      load_default=[],
+  )
+  ```
+
+### Step 1.6 — Write unit tests
+
+Create `tests/unit/test_kasprjoin_types.py`:
+- Test `KasprJoinSpecSchema().load(...)` with valid input
+- Test required field validation (`name`, `leftTable`, `rightTable`, `extractor`)
+- Test `join_type` defaults to `"inner"`
+- Test `output_channel` defaults to `None`
+- Test `camel_to_snake` dump conversion
+- Test `KasprAppComponents` includes `joins` field
+
+### ✅ Phase 1 Checklist
+
+- [ ] `kaspr/types/models/kasprjoin_spec.py` — created
+- [ ] `kaspr/types/models/kasprjoin_resources.py` — created
+- [ ] `kaspr/types/schemas/kasprjoin_spec.py` — created
+- [ ] `kaspr/types/models/__init__.py` — updated exports
+- [ ] `kaspr/types/schemas/__init__.py` — updated exports
+- [ ] `kaspr/types/models/component.py` — added `joins` field
+- [ ] `kaspr/types/schemas/component.py` — added `joins` field
+- [ ] `tests/unit/test_kasprjoin_types.py` — passing
+- [ ] All existing tests still pass
+
+---
+
+## Phase 2: Operator CRD + Resource + Handler
+
+**Repo:** `kaspr-operator`  
+**Goal:** Make the operator recognize, reconcile, and manage `KasprJoin` custom resources.  
+**Depends on:** Phase 1
+
+### Step 2.1 — Create CRD YAML
+
+Create `crds/kasprjoin.crd.yaml`:
+
+```yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: kasprjoins.kaspr.io
+spec:
+  scope: Namespaced
+  group: kaspr.io
+  names:
+    kind: KasprJoin
+    plural: kasprjoins
+    singular: kasprjoin
+    shortNames:
+      - kjoin
+      - kj
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                name:
+                  type: string
+                description:
+                  type: string
+                leftTable:
+                  type: string
+                rightTable:
+                  type: string
+                extractor:
+                  type: object
+                  properties:
+                    entrypoint:
+                      type: string
+                    python:
+                      type: string
+                  required:
+                    - python
+                type:
+                  type: string
+                  enum: ["inner", "left"]
+                  default: "inner"
+                outputChannel:
+                  type: string
+              required:
+                - name
+                - leftTable
+                - rightTable
+                - extractor
+            status:
+              type: object
+              x-kubernetes-preserve-unknown-fields: true
+```
+
+### Step 2.2 — Create resource class
+
+Create `kaspr/resources/kasprjoin.py`:
+
+```python
+from typing import Dict
+from kaspr.types.models import KasprJoinSpec, KasprJoinResources
+from kaspr.utils.objects import cached_property
+from kaspr.resources.appcomponent import BaseAppComponent
+from kaspr.types.models import KasprAppComponents
+
+
+class KasprJoin(BaseAppComponent):
+    """Kaspr Join kubernetes resource."""
+
+    KIND = "KasprJoin"
+    COMPONENT_TYPE = "join"
+    PLURAL_NAME = "kasprjoins"
+    kaspr_resource = KasprJoinResources
+
+    spec: KasprJoinSpec
+
+    @classmethod
+    def from_spec(cls, name, kind, namespace, spec, labels=None):
+        join_resource = KasprJoin(name, kind, namespace, cls.KIND, labels)
+        join_resource.spec = spec
+        join_resource.spec.name = name
+        join_resource.config_map_name = cls.kaspr_resource.config_name(name)
+        join_resource.volume_mount_name = cls.kaspr_resource.volume_mount_name(name)
+        return join_resource
+
+    @classmethod
+    def default(cls):
+        return KasprJoin(
+            name="default", kind=cls.KIND,
+            namespace=None, component_type=cls.COMPONENT_TYPE,
+        )
+
+    @cached_property
+    def app_components(self):
+        return KasprAppComponents(joins=[self.spec])
+```
+
+### Step 2.3 — Register resource export
+
+**Modify** `kaspr/resources/__init__.py`:
+- Import `KasprJoin` from `.kasprjoin`
+- Add to `__all__`
+
+### Step 2.4 — Create handler
+
+Create `kaspr/handlers/kasprjoin.py` with:
+- `@kopf.on.resume/create/update` — reconciliation handler
+  - Deserialize spec via `KasprJoinSpecSchema`
+  - Create `KasprJoin.from_spec()`
+  - Validate app existence
+  - Validate left/right table existence
+  - Call `join_resource.create()` (creates ConfigMap)
+  - Patch status with app/table validation results + configMap + hash
+  - Emit warning events for missing app/tables
+- `@kopf.timer(interval=1)` — patch_resource queue drainer
+- `@kopf.daemon(initial_delay=5.0)` — monitor_join
+  - Continuous monitoring loop (10s interval)
+  - Checks app + left table + right table existence
+  - Updates status when availability changes
+  - Emits events on state transitions
+- `@kopf.timer(initial_delay=5.0, interval=60.0)` — reconcile (full sync)
+  - Periodic full synchronization
+  - Integrates with `SensorDelegate` for metrics
+
+(Full handler code is in the design doc.)
+
+### Step 2.5 — Create example manifests
+
+Create `examples/join/basic.yaml`:
+- Two `KasprTable` resources (orders, products)
+- One `KasprJoin` resource (orders-products-join)
+- One `KasprAgent` consuming the join channel
+
+### Step 2.6 — Manual validation
+
+```bash
+# Apply CRD
+kubectl apply -f crds/kasprjoin.crd.yaml
+
+# Run operator locally
+PYTHONPATH="${PYTHONPATH}:$(pwd)" kopf run kaspr/app.py --verbose --all-namespaces
+
+# Apply example resources
+kubectl apply -f examples/join/basic.yaml
+
+# Verify
+kubectl get kasprjoins
+kubectl get kjoin
+kubectl describe kjoin orders-products-join
+```
+
+### ✅ Phase 2 Checklist
+
+- [ ] `crds/kasprjoin.crd.yaml` — created
+- [ ] `kaspr/resources/kasprjoin.py` — created
+- [ ] `kaspr/resources/__init__.py` — updated
+- [ ] `kaspr/handlers/kasprjoin.py` — created
+- [ ] `examples/join/basic.yaml` — created
+- [ ] CRD applies cleanly to cluster
+- [ ] Operator starts without errors
+- [ ] `kubectl get kasprjoins` works
+- [ ] Status shows app/table validation results
+- [ ] Warning events emitted for missing tables
+- [ ] ConfigMap created with serialized spec
+- [ ] All existing tests still pass
+
+---
+
+## Phase 3: Kaspr Runtime
+
+**Repo:** `kaspr`  
+**Goal:** Make the kaspr runtime understand join definitions, wire up `Table.key_join()`, and register output channels for agents to consume.  
+**Depends on:** Phase 1 (types pattern — not code dependency, just pattern alignment)
+
+### Step 3.1 — Create join model
+
+Create `kaspr/types/models/join/` directory:
+
+**`kaspr/types/models/join/__init__.py`:**
+```python
+from .join import JoinSpec
+```
+
+**`kaspr/types/models/join/join.py`:**
+```python
+from typing import Optional
+from kaspr.types.models.base import SpecComponent
+from kaspr.types.models.pycode import PyCode
+from kaspr.types.app import KasprAppT
+
+
+class JoinSpec(SpecComponent):
+    name: str
+    left_table: str
+    right_table: str
+    extractor: PyCode
+    join_type: Optional[str]        # "inner" or "left"
+    output_channel: Optional[str]
+
+    app: KasprAppT = None
+```
+
+### Step 3.2 — Create join schema
+
+Create `kaspr/types/schemas/join/` directory:
+
+**`kaspr/types/schemas/join/__init__.py`:**
+```python
+from .join import JoinSpecSchema
+```
+
+**`kaspr/types/schemas/join/join.py`:**
+- `JoinSpecSchema` with fields for `name`, `left_table`, `right_table`, `extractor` (nested `PyCodeSchema`), `join_type`, `output_channel`
+- `camelCase` → `snake_case` mapping via `data_key`
+
+### Step 3.3 — Register in type exports
+
+**Modify** `kaspr/types/models/__init__.py`:
+- Import and export `JoinSpec`
+
+**Modify** `kaspr/types/schemas/__init__.py`:
+- Import and export `JoinSpecSchema`
+
+### Step 3.4 — Add joins to `AppSpec`
+
+**Modify** `kaspr/types/models/app.py`:
+- Import `JoinSpec`
+- Add field: `joins_spec: Optional[List[JoinSpec]]`
+- Add property:
+  ```python
+  @property
+  def joins(self):
+      if self.app:
+          if self._joins is None:
+              self._joins = self._wire_joins()
+          return self._joins
+  
+  def _wire_joins(self):
+      """Wire up key joins between tables."""
+      results = []
+      for join_spec in (self.joins_spec or []):
+          left_table = self.app.tables[join_spec.left_table]
+          right_table = self.app.tables[join_spec.right_table]
+          extractor = join_spec.extractor.func
+          inner = (join_spec.join_type or "inner") == "inner"
+          channel = left_table.key_join(
+              right_table, extractor=extractor, inner=inner
+          )
+          channel_name = join_spec.output_channel or f"{join_spec.name}-channel"
+          self.app.register_named_channel(channel_name, channel)
+          results.append(channel)
+      return results
+  ```
+
+**Modify** `kaspr/types/schemas/app.py`:
+- Import `JoinSpecSchema`
+- Add `joins_spec` field to `AppSpecSchema`
+
+### Step 3.5 — Add named channel registry to app
+
+**Modify** `kaspr/core/app.py` (or `kaspr/types/app.py` — wherever `KasprApp` is defined):
+- Add `_named_channels: Dict[str, ChannelT] = {}`
+- Add method:
+  ```python
+  def register_named_channel(self, name: str, channel) -> None:
+      self._named_channels[name] = channel
+  
+  def resolve_named_channel(self, name: str):
+      return self._named_channels.get(name)
+  ```
+
+### Step 3.6 — Update `ChannelSpec.prepare_channel()` for named channels
+
+**Modify** `kaspr/types/models/channel.py`:
+- Update `prepare_channel()` to first try resolving from named channels:
+  ```python
+  def prepare_channel(self) -> KasprChannelT:
+      # Try named channel first (e.g., from a KasprJoin output)
+      named = self.app.resolve_named_channel(self.name)
+      if named is not None:
+          return named
+      # Fall back to creating a new in-memory channel
+      return self.app.channel(self.name)
+  ```
+
+### Step 3.7 — Wire joins in builder
+
+**Modify** `kaspr/core/builder.py`:
+- Import `JoinSpec`
+- Add `_joins` list field
+- Add `_prepare_joins()` method
+- Add `joins` cached_property
+- Update `build()` to call `app.joins` **after** `app.tables`:
+  ```python
+  def build(self) -> None:
+      for app in self.apps:
+          app.agents
+          app.webviews
+          app.tables     # Must come first — creates table instances
+          app.joins      # NEW — wires key joins, registers channels
+          app.tasks
+  ```
+  **Important:** `app.joins` must run after `app.tables` (needs table instances) and before `app.agents` are prepared (so channels are registered before agents try to resolve them). Since `app.agents` is listed first but agents lazily resolve channels, the ordering within `build()` should ensure tables and joins are wired before any agent starts consuming.
+
+### ✅ Phase 3 Checklist
+
+- [ ] `kaspr/types/models/join/__init__.py` — created
+- [ ] `kaspr/types/models/join/join.py` — created
+- [ ] `kaspr/types/schemas/join/__init__.py` — created
+- [ ] `kaspr/types/schemas/join/join.py` — created
+- [ ] `kaspr/types/models/__init__.py` — updated
+- [ ] `kaspr/types/schemas/__init__.py` — updated
+- [ ] `kaspr/types/models/app.py` — added `joins_spec`, `joins` property, `_wire_joins()`
+- [ ] `kaspr/types/schemas/app.py` — added `joins_spec` field
+- [ ] `kaspr/core/app.py` — added `_named_channels`, `register_named_channel()`, `resolve_named_channel()`
+- [ ] `kaspr/types/models/channel.py` — updated `prepare_channel()` to check named channels
+- [ ] `kaspr/core/builder.py` — added joins to `build()` sequence
+- [ ] Unit test: JoinSpec model creation
+- [ ] Unit test: JoinSpecSchema load/dump
+- [ ] Unit test: named channel registration and resolution
+- [ ] Unit test: ChannelSpec resolves named channel
+
+---
+
+## Phase 4: Helm Charts
+
+**Repo:** `kaspr-helm`  
+**Goal:** Ship the CRD and add resource template support so users can deploy `KasprJoin` resources via Helm values.  
+**Depends on:** Phase 2 (CRD YAML)
+
+### Step 4.1 — Add CRD to operator chart
+
+Copy the finalized `kasprjoin.crd.yaml` to:
+```
+kaspr-helm/charts/operator/crds/kasprjoin.crd.yaml
+```
+
+### Step 4.2 — Create resource template
+
+Create `kaspr-helm/charts/resources/templates/joins.yaml`:
+
+```yaml
+{{- if .Values.joins }}
+{{- $root := . -}}
+{{- range .Values.joins }}
+---
+apiVersion: kaspr.io/v1alpha1
+kind: KasprJoin
+metadata:
+  name: {{ .name }}
+spec:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+```
+
+### Step 4.3 — Add example to values.yaml
+
+**Modify** `kaspr-helm/charts/resources/values.yaml`:
+- Add a `joins:` section with a commented-out example:
+  ```yaml
+  # A list of joins to deploy.
+  joins: []
+  # - name: orders-products-join
+  #   description: "Join orders with products by product_id"
+  #   leftTable: orders
+  #   rightTable: products
+  #   extractor:
+  #     entrypoint: get_product_id
+  #     python: |
+  #       def get_product_id(value):
+  #           return value.get("product_id")
+  #   type: inner
+  #   outputChannel: orders-products-joined
+  ```
+
+### Step 4.4 — Bump chart versions
+
+**Modify** `kaspr-helm/charts/operator/Chart.yaml`:
+- Bump `version` (chart version)
+
+**Modify** `kaspr-helm/charts/resources/Chart.yaml`:
+- Bump `version` (chart version)
+
+### Step 4.5 — Validate
+
+```bash
+# Lint
+helm lint charts/operator
+helm lint charts/resources
+
+# Template render
+helm template test charts/resources -f charts/resources/values.yaml --set 'joins[0].name=test-join,joins[0].leftTable=a,joins[0].rightTable=b,joins[0].extractor.python=def f(v): return v'
+
+# Dry-run install
+helm install --dry-run test-operator charts/operator
+```
+
+### ✅ Phase 4 Checklist
+
+- [ ] `charts/operator/crds/kasprjoin.crd.yaml` — added
+- [ ] `charts/resources/templates/joins.yaml` — created
+- [ ] `charts/resources/values.yaml` — added `joins` section
+- [ ] `charts/operator/Chart.yaml` — version bumped
+- [ ] `charts/resources/Chart.yaml` — version bumped
+- [ ] `helm lint` passes for both charts
+- [ ] `helm template` renders KasprJoin correctly
+
+---
+
+## Phase 5: Integration Testing
+
+**Repos:** `kaspr-operator` + `kaspr`  
+**Goal:** Verify the full flow end-to-end — from CRD creation through operator reconciliation to runtime join wiring and data flow.  
+**Depends on:** Phases 2 + 3
+
+### Step 5.1 — Operator integration test
+
+**Create** `tests/unit/test_kasprjoin_resource.py` (in `kaspr-operator`):
+- Test `KasprJoin.from_spec()` creates correct resource
+- Test `app_components` returns `KasprAppComponents` with `joins`
+- Test ConfigMap naming via `KasprJoinResources`
+- Test schema round-trip: YAML → schema load → model → schema dump → matches original
+
+### Step 5.2 — Operator handler test
+
+**Create** `tests/unit/test_kasprjoin_handler.py` (in `kaspr-operator`):
+- Test reconciliation handler with mocked KasprApp/KasprTable fetches
+- Test status patching when app found / not found
+- Test status patching when left table found / not found
+- Test status patching when right table found / not found
+- Test warning events emitted for missing references
+
+### Step 5.3 — Kaspr runtime test
+
+Create tests in `kaspr` repo (or local test scripts):
+- Test `JoinSpec` model creation with all fields
+- Test `JoinSpecSchema` load from YAML-like dict
+- Test named channel registration + resolution
+- Test `ChannelSpec.prepare_channel()` prefers named channel
+- Test that `app.joins` calls `left_table.key_join()` correctly (mock Faust tables)
+
+### Step 5.4 — End-to-end manual test
+
+Use the example manifests from Phase 2:
+
+```bash
+# 1. Deploy operator (with new CRD)
+helm upgrade --install kaspr-operator charts/operator
+
+# 2. Deploy test resources
+kubectl apply -f examples/join/basic.yaml
+
+# 3. Verify CRD status
+kubectl get kjoin -o wide
+kubectl describe kjoin orders-products-join
+
+# 4. Verify ConfigMap created
+kubectl get configmap orders-products-join -o yaml
+
+# 5. Produce test data to raw-orders and raw-products topics
+
+# 6. Verify enriched-orders topic receives joined output
+
+# 7. Test lifecycle: delete join, verify cleanup
+kubectl delete kjoin orders-products-join
+```
+
+### Step 5.5 — Edge case testing
+
+- Create `KasprJoin` before its referenced tables exist → verify warning events, then tables created → verify status transitions to `TableFound`
+- Create `KasprJoin` referencing a non-existent app → verify `AppNotFound` status
+- Delete a referenced table → verify monitor daemon detects and updates status
+- Create multiple joins from the same left table → verify both produce independent channels
+- Test `type: left` join → verify `JoinedValue` emitted with `right=None` when no match
+
+### ✅ Phase 5 Checklist
+
+- [ ] `tests/unit/test_kasprjoin_resource.py` — passing (operator)
+- [ ] `tests/unit/test_kasprjoin_handler.py` — passing (operator)
+- [ ] Kaspr runtime join tests — passing
+- [ ] End-to-end manual test — successful
+- [ ] Edge cases validated
+- [ ] No regressions in existing tests
+
+---
+
+## Phase 6: Documentation
+
+**Repo:** `kaspr-docs`  
+**Goal:** Provide user-facing documentation for the `KasprJoin` CRD.  
+**Depends on:** Phases 2 + 3 (feature complete)
+
+### Step 6.1 — Create user guide page
+
+Create `pages/docs/user-guide/joins.mdx`:
+- **What is a KasprJoin?** — Conceptual overview of table-to-table key joins
+- **How it works** — Simplified protocol diagram (subscription/response)
+- **Creating a join** — Step-by-step YAML walkthrough:
+  1. Define two `KasprTable` resources
+  2. Define a `KasprJoin` connecting them
+  3. Define a `KasprAgent` consuming the join channel
+- **Join types** — `inner` vs `left` with examples
+- **JoinedValue format** — `{"left": ..., "right": ...}` structure
+- **Working with the extractor** — Python function examples
+- **Output channel naming** — Default vs explicit `outputChannel`
+- **Monitoring joins** — `kubectl get kjoin`, status fields, events
+- **Full example** — Complete order enrichment scenario
+
+### Step 6.2 — Update agents page
+
+**Modify** `pages/docs/user-guide/agents.mdx`:
+- Add section: "Consuming a Join Channel"
+- Show `input.channel.name` referencing a join's `outputChannel`
+- Link to the new joins page
+
+### Step 6.3 — Update concepts page
+
+**Modify** `pages/docs/user-guide/concepts.mdx`:
+- Add "Joins" to the resource types overview
+- Brief description + link to full guide
+- Update any architecture diagrams to include joins
+
+### Step 6.4 — Add API reference
+
+**Modify** `pages/docs/api-reference/` (add or update v1alpha1 reference):
+- `KasprJoin` spec fields table
+- Status fields table
+- Short names and plural name
+
+### Step 6.5 — Update navigation
+
+**Modify** `pages/docs/user-guide/_meta.js`:
+- Add `joins` entry in the navigation order
+
+### ✅ Phase 6 Checklist
+
+- [ ] `pages/docs/user-guide/joins.mdx` — created
+- [ ] `pages/docs/user-guide/agents.mdx` — updated with join channel section
+- [ ] `pages/docs/user-guide/concepts.mdx` — updated with joins
+- [ ] API reference — `KasprJoin` documented
+- [ ] `pages/docs/user-guide/_meta.js` — navigation updated
+- [ ] Docs build locally without errors (`pnpm dev`)
+- [ ] All links resolve correctly
+
+---
+
+## Release Checklist
+
+After all phases are complete:
+
+- [ ] **Faust**: Confirm `fk-join` branch is merged to master, `Table.key_join()` is in the release
+- [ ] **kaspr-operator**: All new files created, exports registered, tests passing
+- [ ] **kaspr**: Runtime wiring complete, named channel resolution working, tests passing
+- [ ] **kaspr-helm**: CRD shipped in operator chart, resource template in resources chart, versions bumped
+- [ ] **kaspr-docs**: User guide, concepts, agents page, and API reference all updated
+- [ ] **Version alignment**: Ensure `kaspr` depends on the correct `faust` version (≥ 1.17.10)
+- [ ] **CHANGELOG.md**: Updated in kaspr-operator and kaspr repos
+- [ ] **Tag releases**: Tag all repos consistently
+
+---
+
+## File Index
+
+Quick reference of all files touched across the stack.
+
+### New Files
+
+| Repo | File |
+|------|------|
+| `kaspr-operator` | `crds/kasprjoin.crd.yaml` |
+| `kaspr-operator` | `kaspr/types/models/kasprjoin_spec.py` |
+| `kaspr-operator` | `kaspr/types/models/kasprjoin_resources.py` |
+| `kaspr-operator` | `kaspr/types/schemas/kasprjoin_spec.py` |
+| `kaspr-operator` | `kaspr/resources/kasprjoin.py` |
+| `kaspr-operator` | `kaspr/handlers/kasprjoin.py` |
+| `kaspr-operator` | `examples/join/basic.yaml` |
+| `kaspr-operator` | `tests/unit/test_kasprjoin_types.py` |
+| `kaspr-operator` | `tests/unit/test_kasprjoin_resource.py` |
+| `kaspr-operator` | `tests/unit/test_kasprjoin_handler.py` |
+| `kaspr` | `kaspr/types/models/join/__init__.py` |
+| `kaspr` | `kaspr/types/models/join/join.py` |
+| `kaspr` | `kaspr/types/schemas/join/__init__.py` |
+| `kaspr` | `kaspr/types/schemas/join/join.py` |
+| `kaspr-helm` | `charts/operator/crds/kasprjoin.crd.yaml` |
+| `kaspr-helm` | `charts/resources/templates/joins.yaml` |
+| `kaspr-docs` | `pages/docs/user-guide/joins.mdx` |
+
+### Modified Files
+
+| Repo | File | Change |
+|------|------|--------|
+| `kaspr-operator` | `kaspr/types/models/__init__.py` | Add exports |
+| `kaspr-operator` | `kaspr/types/schemas/__init__.py` | Add exports |
+| `kaspr-operator` | `kaspr/types/models/component.py` | Add `joins` field |
+| `kaspr-operator` | `kaspr/types/schemas/component.py` | Add `joins` field |
+| `kaspr-operator` | `kaspr/resources/__init__.py` | Add `KasprJoin` export |
+| `kaspr` | `kaspr/types/models/__init__.py` | Add `JoinSpec` export |
+| `kaspr` | `kaspr/types/schemas/__init__.py` | Add `JoinSpecSchema` export |
+| `kaspr` | `kaspr/types/models/app.py` | Add `joins_spec`, `joins` property |
+| `kaspr` | `kaspr/types/schemas/app.py` | Add `joins_spec` field |
+| `kaspr` | `kaspr/core/app.py` | Add named channel registry |
+| `kaspr` | `kaspr/types/models/channel.py` | Resolve named channels |
+| `kaspr` | `kaspr/core/builder.py` | Add joins to build sequence |
+| `kaspr-helm` | `charts/resources/values.yaml` | Add `joins` section |
+| `kaspr-helm` | `charts/operator/Chart.yaml` | Version bump |
+| `kaspr-helm` | `charts/resources/Chart.yaml` | Version bump |
+| `kaspr-docs` | `pages/docs/user-guide/agents.mdx` | Add join channel section |
+| `kaspr-docs` | `pages/docs/user-guide/concepts.mdx` | Add joins overview |
+| `kaspr-docs` | `pages/docs/user-guide/_meta.js` | Add navigation entry |

--- a/examples/join/basic.yaml
+++ b/examples/join/basic.yaml
@@ -1,0 +1,106 @@
+# KasprJoin Basic Example
+# This example demonstrates a key join between an orders table and a products table.
+# The join produces an output channel that an agent consumes to create enriched orders.
+#
+# Prerequisites:
+#   - A KasprApp named "order-system" must exist
+#   - Kafka topics "raw-orders" and "raw-products" must exist
+#
+# Usage:
+#   kubectl apply -f examples/join/basic.yaml
+#   kubectl get kjoin
+#   kubectl describe kjoin orders-products-join
+
+---
+# Orders table (keyed by order_id)
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: orders
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: orders
+  description: "Orders keyed by order_id"
+  partitions: 6
+
+---
+# Products table (keyed by product_id)
+apiVersion: kaspr.io/v1alpha1
+kind: KasprTable
+metadata:
+  name: products
+  labels:
+    kaspr.io/app: order-system
+spec:
+  name: products
+  description: "Product catalog keyed by product_id"
+  partitions: 6
+
+---
+# Key join: orders -> products by product_id
+apiVersion: kaspr.io/v1alpha1
+kind: KasprJoin
+metadata:
+  name: orders-products-join
+  labels:
+    kaspr.io/app: order-system
+spec:
+  description: "Join orders with products by product_id"
+  leftTable: orders
+  rightTable: products
+  extractor:
+    entrypoint: get_product_id
+    python: |
+      def get_product_id(order):
+          return order.get("product_id")
+  type: inner
+  outputChannel: orders-products-joined
+
+---
+# Agent that processes the joined order+product stream
+apiVersion: kaspr.io/v1alpha1
+kind: KasprAgent
+metadata:
+  name: process-enriched-orders
+  labels:
+    kaspr.io/app: order-system
+spec:
+  description: "Processes joined order+product records from key join"
+  input:
+    channel:
+      name: orders-products-joined
+  output:
+    topics:
+      - name: enriched-orders
+        keySelector:
+          python: |
+            def get_key(value):
+                return value.get("order_id")
+  processors:
+    pipeline:
+      - enrich
+    init:
+      python: |
+        from datetime import datetime, timezone
+    operations:
+      - name: enrich
+        map:
+          entrypoint: enrich_order
+          python: |
+            def enrich_order(value):
+                """
+                value is a JoinedValue dict:
+                  {"left": <order>, "right": <product>}
+                """
+                order = value["left"]
+                product = value["right"]
+                return {
+                    "order_id": order.get("order_id"),
+                    "product_id": order.get("product_id"),
+                    "quantity": order.get("quantity"),
+                    "product_name": product.get("name"),
+                    "unit_price": product.get("price"),
+                    "total": product.get("price", 0) * order.get("quantity", 0),
+                    "enriched_at": datetime.now(timezone.utc).isoformat()
+                }

--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -13,7 +13,7 @@ try:
 
     env_file = os.environ.get("ENV_FILE", ".env")
     path = find_dotenv(filename=env_file, raise_error_if_not_found=True)
-    print(f"Loading environemnt variables from {path}")
+    print(f"Loading environment variables from {path}")
     load_dotenv(dotenv_path=path)
 
 except Exception:
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.16.2"
+__version__ = "0.17.0"

--- a/kaspr/handlers/kasprjoin.py
+++ b/kaspr/handlers/kasprjoin.py
@@ -1,0 +1,285 @@
+import asyncio
+import kopf
+import logging
+from collections import defaultdict
+from typing import Dict
+from benedict import benedict
+from kaspr.types.schemas import KasprJoinSpecSchema
+from kaspr.types.models import KasprJoinSpec
+from kaspr.resources import KasprJoin, KasprApp, KasprTable
+from kaspr.sensors import SensorDelegate
+
+KIND = "KasprJoin"
+APP_NOT_FOUND = "AppNotFound"
+APP_FOUND = "AppFound"
+LEFT_TABLE_NOT_FOUND = "LeftTableNotFound"
+LEFT_TABLE_FOUND = "LeftTableFound"
+RIGHT_TABLE_NOT_FOUND = "RightTableNotFound"
+RIGHT_TABLE_FOUND = "RightTableFound"
+
+
+def get_sensor() -> SensorDelegate:
+    """Get sensor from KasprJoin class.
+
+    Returns:
+        Sensor instance or None
+    """
+    return getattr(KasprJoin, "sensor", None)
+
+
+# Queue of requests to update KasprJoin status
+patch_request_queues: Dict[str, asyncio.Queue] = defaultdict(asyncio.Queue)
+
+
+class TimerLogFilter(logging.Filter):
+    def filter(self, record):
+        """Timer logs are noisy so we filter them out."""
+        return "Timer " not in record.getMessage()
+
+
+kopf_logger = logging.getLogger("kopf.objects")
+kopf_logger.addFilter(TimerLogFilter())
+
+
+@kopf.on.resume(kind=KIND)
+@kopf.on.create(kind=KIND)
+@kopf.on.update(kind=KIND)
+async def reconciliation(
+    body, spec, name, namespace, logger, labels, patch, annotations, **kwargs
+):
+    """Reconcile KasprJoin resources."""
+    spec_model: KasprJoinSpec = KasprJoinSpecSchema().load(spec)
+    join_resource = KasprJoin.from_spec(
+        name, KIND, namespace, spec_model, dict(labels)
+    )
+    app = await KasprApp.default().fetch(join_resource.app_name, namespace)
+    await join_resource.create()
+
+    # Validate referenced tables exist
+    left_table = await KasprTable.default().fetch(spec_model.left_table, namespace)
+    right_table = await KasprTable.default().fetch(spec_model.right_table, namespace)
+
+    patch.status.update(
+        {
+            "app": {
+                "name": join_resource.app_name,
+                "status": APP_FOUND if app else APP_NOT_FOUND,
+            },
+            "leftTable": {
+                "name": spec_model.left_table,
+                "status": LEFT_TABLE_FOUND if left_table else LEFT_TABLE_NOT_FOUND,
+            },
+            "rightTable": {
+                "name": spec_model.right_table,
+                "status": RIGHT_TABLE_FOUND if right_table else RIGHT_TABLE_NOT_FOUND,
+            },
+            "configMap": join_resource.config_map_name,
+            "hash": join_resource.hash,
+        }
+    )
+
+    if app is None:
+        kopf.warn(
+            body,
+            reason=APP_NOT_FOUND,
+            message=f"KasprApp `{join_resource.app_name}` does not exist in `{namespace or 'default'}` namespace.",
+        )
+    else:
+        kopf.event(
+            body,
+            type="Normal",
+            reason=APP_FOUND,
+            message=f"KasprApp `{join_resource.app_name}` found in `{namespace or 'default'}` namespace.",
+        )
+
+    if left_table is None:
+        kopf.warn(
+            body,
+            reason=LEFT_TABLE_NOT_FOUND,
+            message=f"KasprTable `{spec_model.left_table}` not found in `{namespace or 'default'}` namespace.",
+        )
+    else:
+        kopf.event(
+            body,
+            type="Normal",
+            reason=LEFT_TABLE_FOUND,
+            message=f"KasprTable `{spec_model.left_table}` found in `{namespace or 'default'}` namespace.",
+        )
+
+    if right_table is None:
+        kopf.warn(
+            body,
+            reason=RIGHT_TABLE_NOT_FOUND,
+            message=f"KasprTable `{spec_model.right_table}` not found in `{namespace or 'default'}` namespace.",
+        )
+    else:
+        kopf.event(
+            body,
+            type="Normal",
+            reason=RIGHT_TABLE_FOUND,
+            message=f"KasprTable `{spec_model.right_table}` found in `{namespace or 'default'}` namespace.",
+        )
+
+
+@kopf.timer(KIND, interval=1)
+async def patch_resource(name, patch, **kwargs):
+    queue = patch_request_queues[name]
+
+    def set_patch(request):
+        fields = request["field"].split(".")
+        _patch = patch
+        for field in fields:
+            _patch = getattr(_patch, field)
+        _patch.update(request["value"])
+
+    while not queue.empty():
+        request = queue.get_nowait()
+        if isinstance(request, list):
+            for req in request:
+                set_patch(req)
+        else:
+            set_patch(request)
+
+
+@kopf.daemon(
+    kind=KIND, cancellation_backoff=2.0, cancellation_timeout=5.0, initial_delay=5.0
+)
+async def monitor_join(
+    stopped,
+    name,
+    body,
+    spec,
+    meta,
+    labels,
+    status,
+    namespace,
+    patch,
+    logger: logging.Logger,
+    **kwargs,
+):
+    """Monitor KasprJoin resources for app and table availability."""
+    while not stopped:
+        try:
+            _status = benedict(status, keyattr_dynamic=True)
+            _status_updates = benedict(keyattr_dynamic=True)
+            spec_model: KasprJoinSpec = KasprJoinSpecSchema().load(spec)
+            join_resource = KasprJoin.from_spec(
+                name, KIND, namespace, spec_model, dict(labels)
+            )
+
+            # Check app existence
+            app = await KasprApp.default().fetch(join_resource.app_name, namespace)
+            if app is None and _status.app.status == APP_FOUND:
+                kopf.warn(
+                    body,
+                    reason=APP_NOT_FOUND,
+                    message=f"KasprApp `{join_resource.app_name}` does not exist in `{namespace or 'default'}` namespace.",
+                )
+                _status_updates.app.status = APP_NOT_FOUND
+            elif app and _status.app.status == APP_NOT_FOUND:
+                kopf.event(
+                    body,
+                    type="Normal",
+                    reason=APP_FOUND,
+                    message=f"KasprApp `{join_resource.app_name}` found in `{namespace or 'default'}` namespace.",
+                )
+                _status_updates.app.status = APP_FOUND
+
+            # Check left table existence
+            left_table = await KasprTable.default().fetch(
+                spec_model.left_table, namespace
+            )
+            if (
+                left_table is None
+                and _status.get("leftTable", {}).get("status") == LEFT_TABLE_FOUND
+            ):
+                kopf.warn(
+                    body,
+                    reason=LEFT_TABLE_NOT_FOUND,
+                    message=f"KasprTable `{spec_model.left_table}` not found in `{namespace or 'default'}` namespace.",
+                )
+                _status_updates.leftTable.status = LEFT_TABLE_NOT_FOUND
+            elif (
+                left_table
+                and _status.get("leftTable", {}).get("status") == LEFT_TABLE_NOT_FOUND
+            ):
+                kopf.event(
+                    body,
+                    type="Normal",
+                    reason=LEFT_TABLE_FOUND,
+                    message=f"KasprTable `{spec_model.left_table}` found in `{namespace or 'default'}` namespace.",
+                )
+                _status_updates.leftTable.status = LEFT_TABLE_FOUND
+
+            # Check right table existence
+            right_table = await KasprTable.default().fetch(
+                spec_model.right_table, namespace
+            )
+            if (
+                right_table is None
+                and _status.get("rightTable", {}).get("status") == RIGHT_TABLE_FOUND
+            ):
+                kopf.warn(
+                    body,
+                    reason=RIGHT_TABLE_NOT_FOUND,
+                    message=f"KasprTable `{spec_model.right_table}` not found in `{namespace or 'default'}` namespace.",
+                )
+                _status_updates.rightTable.status = RIGHT_TABLE_NOT_FOUND
+            elif (
+                right_table
+                and _status.get("rightTable", {}).get("status")
+                == RIGHT_TABLE_NOT_FOUND
+            ):
+                kopf.event(
+                    body,
+                    type="Normal",
+                    reason=RIGHT_TABLE_FOUND,
+                    message=f"KasprTable `{spec_model.right_table}` found in `{namespace or 'default'}` namespace.",
+                )
+                _status_updates.rightTable.status = RIGHT_TABLE_FOUND
+
+            if _status_updates:
+                await patch_request_queues[name].put(
+                    [
+                        {"field": "status", "value": _status_updates},
+                    ]
+                )
+
+            await asyncio.sleep(10)
+        except asyncio.CancelledError:
+            logger.info("Monitoring stopped.")
+            break
+        except Exception as e:
+            logger.error(f"Unexpected error during monitoring: {e}")
+            logger.exception(e)
+
+
+@kopf.timer(KIND, initial_delay=5.0, interval=60.0, backoff=10.0)
+async def reconcile(name, spec, namespace, labels, logger: logging.Logger, **kwargs):
+    """Full sync."""
+    sensor = get_sensor()
+    success = True
+    error = None
+
+    try:
+        spec_model: KasprJoinSpec = KasprJoinSpecSchema().load(spec)
+        join_resource = KasprJoin.from_spec(
+            name, KIND, namespace, spec_model, dict(labels)
+        )
+
+        sensor_state = sensor.on_reconcile_start(
+            join_resource.app_name, name, namespace, 0, "timer"
+        )
+
+        logger.debug(f"Reconciling {KIND}/{name} in {namespace} namespace.")
+        await join_resource.synchronize()
+        logger.debug(f"Reconciled {KIND}/{name} in {namespace} namespace.")
+    except Exception as e:
+        success = False
+        error = e
+        logger.error(f"Unexpected error during reconciliation: {e}")
+        logger.exception(e)
+    finally:
+        sensor.on_reconcile_complete(
+            join_resource.app_name, name, namespace, sensor_state, success, error
+        )

--- a/kaspr/resources/__init__.py
+++ b/kaspr/resources/__init__.py
@@ -2,6 +2,7 @@ from .kasprtable import KasprTable
 from .kaspragent import KasprAgent
 from .kasprwebview import KasprWebView
 from .kasprtask import KasprTask
+from .kasprjoin import KasprJoin
 from .kasprapp import KasprApp
 
-__all__ = ["KasprApp", "KasprAgent", "KasprWebView", "KasprTable", "KasprTask"]
+__all__ = ["KasprApp", "KasprAgent", "KasprWebView", "KasprTable", "KasprTask", "KasprJoin"]

--- a/kaspr/resources/kasprjoin.py
+++ b/kaspr/resources/kasprjoin.py
@@ -1,0 +1,47 @@
+from typing import Dict
+from kaspr.types.models import KasprJoinSpec, KasprJoinResources
+from kaspr.utils.objects import cached_property
+from kaspr.resources.appcomponent import BaseAppComponent
+from kaspr.types.models import KasprAppComponents
+
+
+class KasprJoin(BaseAppComponent):
+    """Kaspr Key Join kubernetes resource."""
+
+    KIND = "KasprJoin"
+    COMPONENT_TYPE = "join"
+    PLURAL_NAME = "kasprjoins"
+    kaspr_resource = KasprJoinResources
+
+    spec: KasprJoinSpec
+
+    @classmethod
+    def from_spec(
+        cls,
+        name: str,
+        kind: str,
+        namespace: str,
+        spec: KasprJoinSpec,
+        labels: Dict[str, str] = None,
+    ) -> "KasprJoin":
+        join_resource = KasprJoin(name, kind, namespace, cls.KIND, labels)
+        join_resource.spec = spec
+        join_resource.spec.name = name
+        join_resource.config_map_name = cls.kaspr_resource.config_name(name)
+        join_resource.volume_mount_name = cls.kaspr_resource.volume_mount_name(name)
+        return join_resource
+
+    @classmethod
+    def default(cls) -> "KasprJoin":
+        """Create a default KasprJoin resource."""
+        return KasprJoin(
+            name="default",
+            kind=cls.KIND,
+            namespace=None,
+            component_type=cls.COMPONENT_TYPE,
+        )
+
+    @cached_property
+    def app_components(self) -> KasprAppComponents:
+        """Return the app components."""
+        return KasprAppComponents(joins=[self.spec])

--- a/kaspr/types/models/__init__.py
+++ b/kaspr/types/models/__init__.py
@@ -65,6 +65,8 @@ from .kasprtask_spec import (
     KasprTaskProcessorsSpec,
     KasprTaskSpec,
 )
+from .kasprjoin_resources import KasprJoinResources
+from .kasprjoin_spec import KasprJoinSpec
 from .python_packages import (
     PythonPackagesCache,
     PythonPackagesInstallPolicy,
@@ -133,6 +135,8 @@ __all__ = [
     "KasprTaskProcessorsInit",
     "KasprTaskProcessorsSpec",
     "KasprTaskSpec",
+    "KasprJoinResources",
+    "KasprJoinSpec",
     "PythonPackagesCache",
     "PythonPackagesInstallPolicy",
     "PythonPackagesResources",

--- a/kaspr/types/models/component.py
+++ b/kaspr/types/models/component.py
@@ -4,10 +4,12 @@ from kaspr.types.models.kaspragent_spec import KasprAgentSpec
 from kaspr.types.models.kasprwebview_spec import KasprWebViewSpec
 from kaspr.types.models.kasprtable_spec import KasprTableSpec
 from kaspr.types.models.kasprtask_spec import KasprTaskSpec
+from kaspr.types.models.kasprjoin_spec import KasprJoinSpec
 
 class KasprAppComponents(BaseModel):
     agents: Optional[List[KasprAgentSpec]]
     webviews: Optional[List[KasprWebViewSpec]]
     tables: Optional[List[KasprTableSpec]]
     tasks: Optional[List[KasprTaskSpec]]
+    joins: Optional[List[KasprJoinSpec]]
     

--- a/kaspr/types/models/config.py
+++ b/kaspr/types/models/config.py
@@ -12,6 +12,10 @@ class KasprAppConfig(BaseModel):
     topic_partitions: int
     topic_allow_declare: bool
 
+    # serializers
+    key_serializer: str
+    value_serializer: str
+
     # kafka message scheduler
     scheduler_enabled: bool
     scheduler_debug_stats_enabled: bool

--- a/kaspr/types/models/kasprjoin_resources.py
+++ b/kaspr/types/models/kasprjoin_resources.py
@@ -1,0 +1,35 @@
+class KasprJoinResources:
+    """Encapsulates the naming scheme used for the resources which the Kaspr Operator manages
+    for KasprJoin resources."""
+
+    @classmethod
+    def component_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def config_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def volume_mount_name(cls, cluster_name: str):
+        return f"{cluster_name}-join"
+
+    @classmethod
+    def service_account_name(cls, cluster_name: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def service_name(cls, cluster_name: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def qualified_service_name(cls, cluster_name: str, namespace: str):
+        raise NotImplementedError()
+
+    @classmethod
+    def url(cls, cluster_name: str, namespace: str, port: int):
+        raise NotImplementedError()
+
+    @classmethod
+    def settings_secret_name(cls, cluster_name: str):
+        raise NotImplementedError()

--- a/kaspr/types/models/kasprjoin_spec.py
+++ b/kaspr/types/models/kasprjoin_spec.py
@@ -1,0 +1,15 @@
+from typing import Optional
+from kaspr.types.base import BaseModel
+from kaspr.types.models.code import CodeSpec
+
+
+class KasprJoinSpec(BaseModel):
+    """KasprJoin CRD spec"""
+
+    name: str
+    description: Optional[str]
+    left_table: str
+    right_table: str
+    extractor: CodeSpec
+    join_type: Optional[str]        # "inner" (default) or "left"
+    output_channel: Optional[str]   # Named channel for joined output

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
+            operator_version="0.17.0",
+            version="0.9.0",
+            image="kasprio/kaspr:0.9.0-alpha",
+            supported=True,
+            default=True,
+        ),          
+        KasprVersion(
             operator_version="0.16.0",
             version="0.8.2",
             image="kasprio/kaspr:0.8.2-alpha",
             supported=True,
-            default=True,
+            default=False,
         ),        
         KasprVersion(
             operator_version="0.16.0",

--- a/kaspr/types/schemas/__init__.py
+++ b/kaspr/types/schemas/__init__.py
@@ -55,6 +55,7 @@ from .kasprtask_spec import (
     KasprTaskProcessorFilterOperatorSchema,
     KasprTaskProcessorInitSchema
 )
+from .kasprjoin_spec import KasprJoinSpecSchema
 from .python_packages import (
     PythonPackagesCacheSchema,
     PythonPackagesInstallPolicySchema,
@@ -110,6 +111,7 @@ __all__ = [
     "ContainerTemplateSchema",
     "ConfigMapKeySelectorSchema",
     "SecretKeySelectorSchema",
+    "KasprJoinSpecSchema",
     "PythonPackagesCacheSchema",
     "PythonPackagesInstallPolicySchema",
     "PythonPackagesResourcesSchema",

--- a/kaspr/types/schemas/component.py
+++ b/kaspr/types/schemas/component.py
@@ -5,6 +5,7 @@ from kaspr.types.schemas.kaspragent_spec import KasprAgentSpecSchema
 from kaspr.types.schemas.kasprwebview_spec import KasprWebViewSpecSchema
 from kaspr.types.schemas.kasprtable_spec import KasprTableSpecSchema
 from kaspr.types.schemas.kasprtask_spec import KasprTaskSpecSchema
+from kaspr.types.schemas.kasprjoin_spec import KasprJoinSpecSchema
 
 
 class KasprAppComponentsSchema(BaseSchema):
@@ -31,6 +32,12 @@ class KasprAppComponentsSchema(BaseSchema):
     tasks = fields.List(
         fields.Nested(KasprTaskSpecSchema()),
         data_key="tasks",
+        required=False,
+        load_default=[],
+    )
+    joins = fields.List(
+        fields.Nested(KasprJoinSpecSchema()),
+        data_key="joins",
         required=False,
         load_default=[],
     )

--- a/kaspr/types/schemas/config.py
+++ b/kaspr/types/schemas/config.py
@@ -16,6 +16,10 @@ class KasprAppConfigSchema(BaseSchema):
     topic_partitions: int = fields.Int(data_key="topicPartitions", dump_default=None)
     topic_allow_declare: bool = fields.Bool(data_key="topicAllowDeclare", dump_default=None)
 
+    # serializers
+    key_serializer: str = fields.Str(data_key="keySerializer", dump_default=None)
+    value_serializer: str = fields.Str(data_key="valueSerializer", dump_default=None)
+
     # kafka message scheduler
     scheduler_enabled: bool = fields.Bool(data_key="schedulerEnabled", dump_default=None)
     scheduler_debug_stats_enabled: bool = fields.Bool(data_key="schedulerDebugStatsEnabled", dump_default=None)

--- a/kaspr/types/schemas/kasprjoin_spec.py
+++ b/kaspr/types/schemas/kasprjoin_spec.py
@@ -1,0 +1,30 @@
+from marshmallow import fields, post_dump
+from kaspr.types.base import BaseSchema
+from kaspr.types.models.kasprjoin_spec import KasprJoinSpec
+from kaspr.types.schemas.code import CodeSpecSchema
+from kaspr.utils.helpers import camel_to_snake
+
+
+class KasprJoinSpecSchema(BaseSchema):
+    __model__ = KasprJoinSpec
+
+    name = fields.String(data_key="name", required=True)
+    description = fields.String(
+        data_key="description", allow_none=True, load_default=None
+    )
+    left_table = fields.String(data_key="leftTable", required=True)
+    right_table = fields.String(data_key="rightTable", required=True)
+    extractor = fields.Nested(
+        CodeSpecSchema(), data_key="extractor", required=True
+    )
+    join_type = fields.String(
+        data_key="type", allow_none=True, load_default="inner"
+    )
+    output_channel = fields.String(
+        data_key="outputChannel", allow_none=True, load_default=None
+    )
+
+    @post_dump
+    def camel_to_snake_dump(self, data, **kwargs):
+        """Convert data keys from camelCase to snake_case."""
+        return camel_to_snake(data)

--- a/kaspr/types/schemas/kasprjoin_spec.py
+++ b/kaspr/types/schemas/kasprjoin_spec.py
@@ -8,7 +8,7 @@ from kaspr.utils.helpers import camel_to_snake
 class KasprJoinSpecSchema(BaseSchema):
     __model__ = KasprJoinSpec
 
-    name = fields.String(data_key="name", required=True)
+    name = fields.String(data_key="name", allow_none=True, load_default=None)
     description = fields.String(
         data_key="description", allow_none=True, load_default=None
     )

--- a/tests/unit/test_kasprjoin_types.py
+++ b/tests/unit/test_kasprjoin_types.py
@@ -14,7 +14,6 @@ class TestKasprJoinSpecSchema:
     def setup_method(self):
         self.schema = KasprJoinSpecSchema()
         self.valid_input = {
-            "name": "orders-products-join",
             "description": "Join orders with products by product_id",
             "leftTable": "orders",
             "rightTable": "products",
@@ -29,7 +28,7 @@ class TestKasprJoinSpecSchema:
     def test_load_valid_input(self):
         result = self.schema.load(self.valid_input)
         assert isinstance(result, KasprJoinSpec)
-        assert result.name == "orders-products-join"
+        assert result.name is None  # name is derived from metadata.name, not spec
         assert result.description == "Join orders with products by product_id"
         assert result.left_table == "orders"
         assert result.right_table == "products"
@@ -40,7 +39,6 @@ class TestKasprJoinSpecSchema:
 
     def test_load_minimal_input(self):
         minimal = {
-            "name": "test-join",
             "leftTable": "left",
             "rightTable": "right",
             "extractor": {
@@ -49,7 +47,7 @@ class TestKasprJoinSpecSchema:
         }
         result = self.schema.load(minimal)
         assert isinstance(result, KasprJoinSpec)
-        assert result.name == "test-join"
+        assert result.name is None  # name is derived from metadata.name
         assert result.left_table == "left"
         assert result.right_table == "right"
         assert result.description is None
@@ -58,7 +56,6 @@ class TestKasprJoinSpecSchema:
 
     def test_join_type_defaults_to_inner(self):
         data = {
-            "name": "test-join",
             "leftTable": "a",
             "rightTable": "b",
             "extractor": {"python": "def f(v): return v"},
@@ -68,7 +65,6 @@ class TestKasprJoinSpecSchema:
 
     def test_output_channel_defaults_to_none(self):
         data = {
-            "name": "test-join",
             "leftTable": "a",
             "rightTable": "b",
             "extractor": {"python": "def f(v): return v"},
@@ -76,19 +72,8 @@ class TestKasprJoinSpecSchema:
         result = self.schema.load(data)
         assert result.output_channel is None
 
-    def test_load_missing_name_raises(self):
-        data = {
-            "leftTable": "a",
-            "rightTable": "b",
-            "extractor": {"python": "def f(v): return v"},
-        }
-        with pytest.raises(ValidationError) as exc_info:
-            self.schema.load(data)
-        assert "name" in exc_info.value.messages
-
     def test_load_missing_left_table_raises(self):
         data = {
-            "name": "test-join",
             "rightTable": "b",
             "extractor": {"python": "def f(v): return v"},
         }
@@ -98,7 +83,6 @@ class TestKasprJoinSpecSchema:
 
     def test_load_missing_right_table_raises(self):
         data = {
-            "name": "test-join",
             "leftTable": "a",
             "extractor": {"python": "def f(v): return v"},
         }
@@ -108,7 +92,6 @@ class TestKasprJoinSpecSchema:
 
     def test_load_missing_extractor_raises(self):
         data = {
-            "name": "test-join",
             "leftTable": "a",
             "rightTable": "b",
         }
@@ -137,7 +120,6 @@ class TestKasprJoinSpecSchema:
 
     def test_load_left_join_type(self):
         data = {
-            "name": "test-join",
             "leftTable": "a",
             "rightTable": "b",
             "extractor": {"python": "def f(v): return v"},
@@ -192,7 +174,6 @@ class TestKasprAppComponentsWithJoins:
             "tasks": [],
             "joins": [
                 {
-                    "name": "test-join",
                     "leftTable": "a",
                     "rightTable": "b",
                     "extractor": {"python": "def f(v): return v"},
@@ -203,7 +184,7 @@ class TestKasprAppComponentsWithJoins:
         assert hasattr(result, "joins")
         assert len(result.joins) == 1
         assert isinstance(result.joins[0], KasprJoinSpec)
-        assert result.joins[0].name == "test-join"
+        assert result.joins[0].left_table == "a"
 
     def test_components_schema_joins_defaults_to_empty(self):
         schema = KasprAppComponentsSchema()
@@ -221,13 +202,11 @@ class TestKasprAppComponentsWithJoins:
         data = {
             "joins": [
                 {
-                    "name": "join-1",
                     "leftTable": "a",
                     "rightTable": "b",
                     "extractor": {"python": "def f(v): return v.get('id')"},
                 },
                 {
-                    "name": "join-2",
                     "leftTable": "a",
                     "rightTable": "c",
                     "extractor": {"python": "def g(v): return v.get('key')"},
@@ -238,8 +217,10 @@ class TestKasprAppComponentsWithJoins:
         }
         result = schema.load(data)
         assert len(result.joins) == 2
-        assert result.joins[0].name == "join-1"
+        assert result.joins[0].left_table == "a"
+        assert result.joins[0].right_table == "b"
         assert result.joins[0].join_type == "inner"
-        assert result.joins[1].name == "join-2"
+        assert result.joins[1].left_table == "a"
+        assert result.joins[1].right_table == "c"
         assert result.joins[1].join_type == "left"
         assert result.joins[1].output_channel == "custom-channel"

--- a/tests/unit/test_kasprjoin_types.py
+++ b/tests/unit/test_kasprjoin_types.py
@@ -1,0 +1,245 @@
+"""Unit tests for KasprJoin types (model + schema)."""
+
+import pytest
+from marshmallow import ValidationError
+from kaspr.types.models.kasprjoin_spec import KasprJoinSpec
+from kaspr.types.models.kasprjoin_resources import KasprJoinResources
+from kaspr.types.schemas.kasprjoin_spec import KasprJoinSpecSchema
+from kaspr.types.schemas.component import KasprAppComponentsSchema
+
+
+class TestKasprJoinSpecSchema:
+    """Tests for KasprJoinSpecSchema load/dump."""
+
+    def setup_method(self):
+        self.schema = KasprJoinSpecSchema()
+        self.valid_input = {
+            "name": "orders-products-join",
+            "description": "Join orders with products by product_id",
+            "leftTable": "orders",
+            "rightTable": "products",
+            "extractor": {
+                "entrypoint": "get_product_id",
+                "python": "def get_product_id(value):\n    return value.get('product_id')",
+            },
+            "type": "inner",
+            "outputChannel": "orders-products-joined",
+        }
+
+    def test_load_valid_input(self):
+        result = self.schema.load(self.valid_input)
+        assert isinstance(result, KasprJoinSpec)
+        assert result.name == "orders-products-join"
+        assert result.description == "Join orders with products by product_id"
+        assert result.left_table == "orders"
+        assert result.right_table == "products"
+        assert result.extractor.entrypoint == "get_product_id"
+        assert result.extractor.python.startswith("def get_product_id")
+        assert result.join_type == "inner"
+        assert result.output_channel == "orders-products-joined"
+
+    def test_load_minimal_input(self):
+        minimal = {
+            "name": "test-join",
+            "leftTable": "left",
+            "rightTable": "right",
+            "extractor": {
+                "python": "def extract(v): return v.get('id')",
+            },
+        }
+        result = self.schema.load(minimal)
+        assert isinstance(result, KasprJoinSpec)
+        assert result.name == "test-join"
+        assert result.left_table == "left"
+        assert result.right_table == "right"
+        assert result.description is None
+        assert result.join_type == "inner"
+        assert result.output_channel is None
+
+    def test_join_type_defaults_to_inner(self):
+        data = {
+            "name": "test-join",
+            "leftTable": "a",
+            "rightTable": "b",
+            "extractor": {"python": "def f(v): return v"},
+        }
+        result = self.schema.load(data)
+        assert result.join_type == "inner"
+
+    def test_output_channel_defaults_to_none(self):
+        data = {
+            "name": "test-join",
+            "leftTable": "a",
+            "rightTable": "b",
+            "extractor": {"python": "def f(v): return v"},
+        }
+        result = self.schema.load(data)
+        assert result.output_channel is None
+
+    def test_load_missing_name_raises(self):
+        data = {
+            "leftTable": "a",
+            "rightTable": "b",
+            "extractor": {"python": "def f(v): return v"},
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "name" in exc_info.value.messages
+
+    def test_load_missing_left_table_raises(self):
+        data = {
+            "name": "test-join",
+            "rightTable": "b",
+            "extractor": {"python": "def f(v): return v"},
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "leftTable" in exc_info.value.messages
+
+    def test_load_missing_right_table_raises(self):
+        data = {
+            "name": "test-join",
+            "leftTable": "a",
+            "extractor": {"python": "def f(v): return v"},
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "rightTable" in exc_info.value.messages
+
+    def test_load_missing_extractor_raises(self):
+        data = {
+            "name": "test-join",
+            "leftTable": "a",
+            "rightTable": "b",
+        }
+        with pytest.raises(ValidationError) as exc_info:
+            self.schema.load(data)
+        assert "extractor" in exc_info.value.messages
+
+    def test_dump_converts_to_camel_case(self):
+        model = KasprJoinSpec(
+            name="test-join",
+            description=None,
+            left_table="a",
+            right_table="b",
+            extractor={"python": "def f(v): return v", "entrypoint": "f"},
+            join_type="inner",
+            output_channel="test-channel",
+        )
+        result = self.schema.dump(model)
+        # Schema uses data_key mappings: leftTable -> left_table, rightTable -> right_table
+        # "type" stays as "type" (no camelCase conversion needed)
+        # "outputChannel" -> output_channel
+        assert "left_table" in result
+        assert "right_table" in result
+        assert "type" in result
+        assert "output_channel" in result
+
+    def test_load_left_join_type(self):
+        data = {
+            "name": "test-join",
+            "leftTable": "a",
+            "rightTable": "b",
+            "extractor": {"python": "def f(v): return v"},
+            "type": "left",
+        }
+        result = self.schema.load(data)
+        assert result.join_type == "left"
+
+
+class TestKasprJoinResources:
+    """Tests for KasprJoinResources naming scheme."""
+
+    def test_component_name(self):
+        assert KasprJoinResources.component_name("my-app") == "my-app-join"
+
+    def test_config_name(self):
+        assert KasprJoinResources.config_name("my-app") == "my-app-join"
+
+    def test_volume_mount_name(self):
+        assert KasprJoinResources.volume_mount_name("my-app") == "my-app-join"
+
+    def test_service_account_name_raises(self):
+        with pytest.raises(NotImplementedError):
+            KasprJoinResources.service_account_name("my-app")
+
+    def test_service_name_raises(self):
+        with pytest.raises(NotImplementedError):
+            KasprJoinResources.service_name("my-app")
+
+    def test_qualified_service_name_raises(self):
+        with pytest.raises(NotImplementedError):
+            KasprJoinResources.qualified_service_name("my-app", "default")
+
+    def test_url_raises(self):
+        with pytest.raises(NotImplementedError):
+            KasprJoinResources.url("my-app", "default", 8080)
+
+    def test_settings_secret_name_raises(self):
+        with pytest.raises(NotImplementedError):
+            KasprJoinResources.settings_secret_name("my-app")
+
+
+class TestKasprAppComponentsWithJoins:
+    """Tests for KasprAppComponents with joins field."""
+
+    def test_components_schema_includes_joins(self):
+        schema = KasprAppComponentsSchema()
+        data = {
+            "agents": [],
+            "webviews": [],
+            "tables": [],
+            "tasks": [],
+            "joins": [
+                {
+                    "name": "test-join",
+                    "leftTable": "a",
+                    "rightTable": "b",
+                    "extractor": {"python": "def f(v): return v"},
+                }
+            ],
+        }
+        result = schema.load(data)
+        assert hasattr(result, "joins")
+        assert len(result.joins) == 1
+        assert isinstance(result.joins[0], KasprJoinSpec)
+        assert result.joins[0].name == "test-join"
+
+    def test_components_schema_joins_defaults_to_empty(self):
+        schema = KasprAppComponentsSchema()
+        data = {
+            "agents": [],
+            "webviews": [],
+            "tables": [],
+            "tasks": [],
+        }
+        result = schema.load(data)
+        assert result.joins == []
+
+    def test_components_schema_multiple_joins(self):
+        schema = KasprAppComponentsSchema()
+        data = {
+            "joins": [
+                {
+                    "name": "join-1",
+                    "leftTable": "a",
+                    "rightTable": "b",
+                    "extractor": {"python": "def f(v): return v.get('id')"},
+                },
+                {
+                    "name": "join-2",
+                    "leftTable": "a",
+                    "rightTable": "c",
+                    "extractor": {"python": "def g(v): return v.get('key')"},
+                    "type": "left",
+                    "outputChannel": "custom-channel",
+                },
+            ],
+        }
+        result = schema.load(data)
+        assert len(result.joins) == 2
+        assert result.joins[0].name == "join-1"
+        assert result.joins[0].join_type == "inner"
+        assert result.joins[1].name == "join-2"
+        assert result.joins[1].join_type == "left"
+        assert result.joins[1].output_channel == "custom-channel"


### PR DESCRIPTION
This pull request introduces support for a new custom resource type, `KasprJoin`, enabling declarative key-based joins between tables in the Kaspr platform. The implementation includes the Kubernetes CRD, handler logic, resource models, and an example manifest. Additional minor changes include a version bump and typo fix.

**KasprJoin resource support:**

* Added `KasprJoin` CustomResourceDefinition (`crds/kasprjoin.crd.yaml`) to define the schema for key-based joins between tables, including fields for table references, Python extractor code, join type, and output channel.
* Implemented the `KasprJoin` handler (`kaspr/handlers/kasprjoin.py`) for reconciliation, monitoring, and patching status, including validation of referenced resources and event emission.
* Created the `KasprJoin` resource model (`kaspr/resources/kasprjoin.py`) and integrated it into the resource registry (`kaspr/resources/__init__.py`). [[1]](diffhunk://#diff-e1cec9a94d2ea40959d53a35a5866ec9a6cdb80a87ff544b7cf0c1606151343cR1-R47) [[2]](diffhunk://#diff-c0d88fa8a904e570f8205d9cea02830e255d88ed52614d8fc929b9eca7a9eaf1R5-R8)
* Defined supporting models and schemas for `KasprJoin`, including `KasprJoinSpec`, `KasprJoinResources`, and schema registration. [[1]](diffhunk://#diff-971b4157d55a0917fceb5340000b474862dfeaef091599168500acd12b27bbcaR1-R15) [[2]](diffhunk://#diff-5f2cde871cdb8a6811c60ce9ef10d31989fbfe2902c752fd5b8d205a73563defR1-R35) [[3]](diffhunk://#diff-8555c0c6e7ca3be19b6958098c4b103fa4af5a85737284f4c9919ffee177640fR68-R69) [[4]](diffhunk://#diff-8555c0c6e7ca3be19b6958098c4b103fa4af5a85737284f4c9919ffee177640fR138-R139) [[5]](diffhunk://#diff-75b782fb7b4ce2da8537798831b5ff4f1517a5adbe08165812eb4f872f4d5ea3R58) [[6]](diffhunk://#diff-58e8ee5160ee5404a73e2cc1396d72d6ef7d1ec8e062c2c71c512bbd36d1916cR7-R14)

**Documentation and examples:**

* Added a comprehensive example manifest (`examples/join/basic.yaml`) demonstrating how to define tables, a join, and an agent that consumes the joined output.

**Other changes:**

* Bumped the Kaspr Python package version to `0.17.0` and updated the default operator version mapping. [[1]](diffhunk://#diff-2fe653280a4f04f8f978c8e4f55b4a2cbb71bace93e5fc4fc848ada99b7ddbd0L42-R42) [[2]](diffhunk://#diff-72ae4e4a2b1e86ceb013a042a92b9185c3a7ec98a62833e45a854dfcfc3d30daR25-R37)
* Fixed a typo in an environment variable log message.
* Added new serializer fields to `KasprAppConfig` for future extensibility.