### PR TITLE
Add custom image registry; bump version

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.17.1"
+__version__ = "0.17.2"

--- a/kaspr/resources/kasprapp.py
+++ b/kaspr/resources/kasprapp.py
@@ -852,8 +852,12 @@ class KasprApp(BaseResource):
 
     def prepare_image(self) -> str:
         """Container image to use."""
-        # Use image provide in spec, otherwise use the image defined for the given version
-        return self._image if self._image else self.version.image
+        # Use image provided in spec, otherwise use the image defined for the given version
+        image = self._image if self._image else self.version.image
+        # Prepend custom registry if configured
+        if self.conf.kaspr_image_registry:
+            image = f"{self.conf.kaspr_image_registry.rstrip('/')}/{image}"
+        return image
 
     def prepare_service(self) -> V1Service:
         """Build service resource."""

--- a/kaspr/types/models/version_resources.py
+++ b/kaspr/types/models/version_resources.py
@@ -23,11 +23,18 @@ class KasprVersionResources:
     # TODO: This should be moved to a configuration file
     _VERSIONS = (
         KasprVersion(
-            operator_version="0.17.0",
+            operator_version="0.17.2",
             version="0.9.1",
             image="kasprio/kaspr:0.9.1-alpha",
             supported=True,
             default=True,
+        ),        
+        KasprVersion(
+            operator_version="0.17.0",
+            version="0.9.1",
+            image="kasprio/kaspr:0.9.1-alpha",
+            supported=True,
+            default=False,
         ),          
         KasprVersion(
             operator_version="0.16.0",

--- a/kaspr/types/settings.py
+++ b/kaspr/types/settings.py
@@ -66,6 +66,11 @@ CLIENT_STATUS_CHECK_TIMEOUT_SECONDS = float(
     _getenv("CLIENT_STATUS_CHECK_TIMEOUT_SECONDS", 15.0)
 )
 
+#: Custom container image registry to use instead of Docker Hub
+#: e.g. "sipapexdev.azurecr.io" will turn "kasprio/kaspr:0.9.1-alpha"
+#: into "sipapexdev.azurecr.io/kasprio/kaspr:0.9.1-alpha"
+KASPR_IMAGE_REGISTRY = str(_getenv("KASPR_IMAGE_REGISTRY", ""))
+
 #: Enable automatic rebalance when Kafka subscriptions change
 AUTO_REBALANCE_ENABLED = bool(
     _getenv("AUTO_REBALANCE_ENABLED", True)
@@ -93,6 +98,7 @@ class Settings:
     auto_rebalance_enabled: bool = AUTO_REBALANCE_ENABLED
     hung_member_detection_enabled: bool = HUNG_MEMBER_DETECTION_ENABLED
     hung_rebalancing_threshold_seconds: int = HUNG_REBALANCING_THRESHOLD_SECONDS
+    kaspr_image_registry: str = KASPR_IMAGE_REGISTRY
 
     def __init__(
         self,


### PR DESCRIPTION
Add KASPR_IMAGE_REGISTRY setting and expose it via Settings.kaspr_image_registry, allowing prepare_image() to prepend a custom registry to container images. Update kasprapp.prepare_image to use the configured registry when present. Bump package __version__ to 0.17.2 and update the KasprVersionResources entries (operator_version/version metadata adjusted).