### PR TITLE
Bump version to 0.17.3; remove registry example

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.17.2"
+__version__ = "0.17.3"

--- a/kaspr/types/settings.py
+++ b/kaspr/types/settings.py
@@ -67,8 +67,6 @@ CLIENT_STATUS_CHECK_TIMEOUT_SECONDS = float(
 )
 
 #: Custom container image registry to use instead of Docker Hub
-#: e.g. "sipapexdev.azurecr.io" will turn "kasprio/kaspr:0.9.1-alpha"
-#: into "sipapexdev.azurecr.io/kasprio/kaspr:0.9.1-alpha"
 KASPR_IMAGE_REGISTRY = str(_getenv("KASPR_IMAGE_REGISTRY", ""))
 
 #: Enable automatic rebalance when Kafka subscriptions change


### PR DESCRIPTION
Update package version to 0.17.3 in kaspr/__init__.py. Also remove the example comment block describing KASPR_IMAGE_REGISTRY in kaspr/types/settings.py to tidy up module-level comments.