### PR TITLE
Bump default kaspr to 0.10.1

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"

--- a/kaspr/types/config/kaspr_versions.yaml
+++ b/kaspr/types/config/kaspr_versions.yaml
@@ -1,7 +1,7 @@
 versions:
-  - operator_version: "0.18.0"
-    version: "0.10.0"
-    image: "kasprio/kaspr:0.10.0-alpha"
+  - operator_version: "0.18.1"
+    version: "0.10.1"
+    image: "kasprio/kaspr:0.10.1-alpha"
     supported: true
     default: true
   - operator_version: "0.17.2"


### PR DESCRIPTION
Update package __version__ to 0.18.1 and align kaspr_versions.yaml metadata to the new release: operator_version set to 0.18.1, version to 0.10.1, and image to kasprio/kaspr:0.10.1-alpha. This ensures the version matrix reflects the new package release.