### PR TITLE
Bump kaspr to 0.10.3

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,4 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.18.2"
+__version__ = "0.18.3"

--- a/kaspr/types/config/kaspr_versions.yaml
+++ b/kaspr/types/config/kaspr_versions.yaml
@@ -1,9 +1,14 @@
 versions:
+  - operator_version: "0.18.3"
+    version: "0.10.3"
+    image: "kasprio/kaspr:0.10.3-alpha"
+    supported: true
+    default: true
   - operator_version: "0.18.2"
     version: "0.10.2"
     image: "kasprio/kaspr:0.10.2-alpha"
     supported: true
-    default: true
+    default: false
   - operator_version: "0.18.1"
     version: "0.10.1"
     image: "kasprio/kaspr:0.10.1-alpha"


### PR DESCRIPTION
Update package __version__ to 0.18.3 and add a new entry in kaspr_versions.yaml for operator_version 0.18.3 / version 0.10.3 with image kasprio/kaspr:0.10.3-alpha. Mark the new entry as supported and default, and unset the previous default (0.18.2 / 0.10.2).