### PR TITLE
Bump operator version to 0.18.5

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,4 +39,5 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.18.4"
+__version__ = "0.18.5"
+    

--- a/kaspr/types/config/kaspr_versions.yaml
+++ b/kaspr/types/config/kaspr_versions.yaml
@@ -1,9 +1,14 @@
 versions:
+  - operator_version: "0.18.5"
+    version: "0.10.5"
+    image: "kasprio/kaspr:0.10.5-alpha"
+    supported: true
+    default: true
   - operator_version: "0.18.4"
     version: "0.10.4"
     image: "kasprio/kaspr:0.10.4-alpha"
     supported: true
-    default: true
+    default: false
   - operator_version: "0.18.3"
     version: "0.10.3"
     image: "kasprio/kaspr:0.10.3-alpha"


### PR DESCRIPTION
Update package __version__ to 0.18.5 and add a new entry in kaspr/types/config/kaspr_versions.yaml for operator_version 0.18.5 (version 0.10.5, image kasprio/kaspr:0.10.5-alpha). Mark the new entry as the default and clear the default flag from the previous 0.18.4 entry.