### PR TITLE
Release v0.18.10

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,5 +39,5 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.18.9"
+__version__ = "0.18.10"
     

--- a/kaspr/types/config/kaspr_versions.yaml
+++ b/kaspr/types/config/kaspr_versions.yaml
@@ -1,9 +1,14 @@
 versions:
+  - operator_version: "0.18.10"
+    version: "0.11.4"
+    image: "kasprio/kaspr:0.11.4"
+    supported: true
+    default: true
   - operator_version: "0.18.7"
     version: "0.11.2"
     image: "kasprio/kaspr:0.11.2"
     supported: true
-    default: true
+    default: false
   - operator_version: "0.18.6"
     version: "0.10.6"
     image: "kasprio/kaspr:0.10.6"


### PR DESCRIPTION
Kaspr operator v0.18.10

- Update kaspr default version to 0.11.4