### PR TITLE
Release v0.18.27

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,5 +39,5 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.18.26"
+__version__ = "0.18.27"
     

--- a/kaspr/types/config/kaspr_versions.yaml
+++ b/kaspr/types/config/kaspr_versions.yaml
@@ -1,9 +1,14 @@
 versions:
+  - operator_version: "0.18.27"
+    version: "0.11.10"
+    image: "kasprio/kaspr:0.11.10"
+    supported: true
+    default: true
   - operator_version: "0.18.26"
     version: "0.11.9"
     image: "kasprio/kaspr:0.11.9"
     supported: true
-    default: true
+    default: false
   - operator_version: "0.18.25"
     version: "0.11.8"
     image: "kasprio/kaspr:0.11.8"


### PR DESCRIPTION
Kaspr operator v0.18.27

- Update kaspr default version to 0.11.10