### PR TITLE
Add passThrough support to TopicOut specs

### DIFF
--- a/crds/kasprtask.crd.yaml
+++ b/crds/kasprtask.crd.yaml
@@ -133,6 +133,9 @@ spec:
                               ack:
                                 type: boolean
                                 description: Wait for acknoledgement from the broker before considering the message sent
+                              passThrough:
+                                type: boolean
+                                description: Preserve the original processor value for downstream pipeline steps after publishing.
                               keySerializer:
                                 type: string
                                 description: Serializer for the key of the message

--- a/crds/kasprwebview.crd.yaml
+++ b/crds/kasprwebview.crd.yaml
@@ -238,6 +238,9 @@ spec:
                               ack:
                                 type: boolean
                                 description: Wait for acknoledgement from the broker before considering the message sent
+                              passThrough:
+                                type: boolean
+                                description: Preserve the original processor value for downstream pipeline steps after publishing.
                               keySerializer:
                                 type: string
                                 description: Serializer for the key of the message

--- a/kaspr/types/models/topicout.py
+++ b/kaspr/types/models/topicout.py
@@ -5,6 +5,7 @@ from kaspr.types.models.code import CodeSpec
 class TopicOutSpec(BaseModel):
     name: str
     name_selector: Optional[CodeSpec]
+    pass_through: Optional[bool]
     ack: Optional[bool]
     key_serializer: Optional[str]
     value_serializer: Optional[str]

--- a/kaspr/types/schemas/topicout.py
+++ b/kaspr/types/schemas/topicout.py
@@ -12,6 +12,9 @@ class TopicOutSpecSchema(BaseSchema):
     name_selector = fields.Nested(
         CodeSpecSchema(), data_key="nameSelector", required=False, load_default=None
     )
+    pass_through = fields.Bool(
+        data_key="passThrough", required=False, load_default=False
+    )
     ack = fields.Bool(data_key="ack", required=False, load_default=None)
     key_serializer = fields.Str(
         data_key="keySerializer", required=False, load_default=None

--- a/tests/unit/test_topicout_schema.py
+++ b/tests/unit/test_topicout_schema.py
@@ -1,0 +1,47 @@
+"""Unit tests for TopicOutSpec schema pass-through support."""
+
+import sys
+import types
+from pathlib import Path
+
+
+package_root = Path(__file__).resolve().parents[2] / "kaspr"
+if "kaspr" not in sys.modules:
+    package = types.ModuleType("kaspr")
+    package.__path__ = [str(package_root)]
+    sys.modules["kaspr"] = package
+if "jsonpickle" not in sys.modules:
+    sys.modules["jsonpickle"] = types.ModuleType("jsonpickle")
+
+from kaspr.types.schemas.kasprtask_spec import KasprTaskProcessorTopicSendOperatorSchema
+from kaspr.types.schemas.kasprwebview_spec import (
+    KasprWebViewProcessorTopicSendOperatorSchema,
+)
+from kaspr.types.schemas.topicout import TopicOutSpecSchema
+
+
+def test_topicout_schema_loads_pass_through_from_crd_field():
+    schema = TopicOutSpecSchema()
+
+    result = schema.load({"name": "materialization-requests", "passThrough": True})
+
+    assert result.name == "materialization-requests"
+    assert result.pass_through is True
+
+
+def test_webview_topic_send_schema_dumps_pass_through_for_runtime_config():
+    schema = KasprWebViewProcessorTopicSendOperatorSchema()
+    model = schema.load({"name": "materialization-requests", "passThrough": True})
+
+    result = schema.dump(model)
+
+    assert result["name"] == "materialization-requests"
+    assert result["pass_through"] is True
+
+
+def test_task_topic_send_schema_defaults_pass_through_false():
+    schema = KasprTaskProcessorTopicSendOperatorSchema()
+
+    result = schema.load({"name": "materialization-requests"})
+
+    assert result.pass_through is False


### PR DESCRIPTION
Introduces `passThrough` as an optional boolean in KasprTask and KasprWebView CRDs, wires it through the TopicOut model/schema as `pass_through`, and sets a default of `False` when omitted. Adds unit tests to verify CRD loading, runtime dump behavior, and default handling.