### PR TITLE
Release v0.18.40

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,5 +39,5 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.18.39"
+__version__ = "0.18.40"
     

--- a/kaspr/types/config/kaspr_versions.yaml
+++ b/kaspr/types/config/kaspr_versions.yaml
@@ -1,9 +1,14 @@
 versions:
+  - operator_version: "0.18.40"
+    version: "0.11.13"
+    image: "kasprio/kaspr:0.11.13"
+    supported: true
+    default: true
   - operator_version: "0.18.39"
     version: "0.11.12"
     image: "kasprio/kaspr:0.11.12"
     supported: true
-    default: true
+    default: false
   - operator_version: "0.18.29"
     version: "0.11.11"
     image: "kasprio/kaspr:0.11.11"


### PR DESCRIPTION
Kaspr operator v0.18.40

- Update kaspr default version to 0.11.13