### PR TITLE
Release v0.18.49

### DIFF
--- a/kaspr/__init__.py
+++ b/kaspr/__init__.py
@@ -39,5 +39,5 @@ __all__ = [
     "kasprtask",
 ]
 
-__version__ = "0.18.48"
+__version__ = "0.18.49"
     

--- a/kaspr/types/config/kaspr_versions.yaml
+++ b/kaspr/types/config/kaspr_versions.yaml
@@ -1,9 +1,14 @@
 versions:
+  - operator_version: "0.18.49"
+    version: "0.11.18"
+    image: "kasprio/kaspr:0.11.18"
+    supported: true
+    default: true
   - operator_version: "0.18.47"
     version: "0.11.17"
     image: "kasprio/kaspr:0.11.17"
     supported: true
-    default: true
+    default: false
   - operator_version: "0.18.46"
     version: "0.11.16"
     image: "kasprio/kaspr:0.11.16"


### PR DESCRIPTION
Kaspr operator v0.18.49

- Update kaspr default version to 0.11.18